### PR TITLE
Feat: Match javascript locale to Rails locale

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-translate-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-translate-button.js.es6
@@ -8,7 +8,7 @@ import User from 'discourse/models/user';
 function translatePost(post) {
   return Discourse.ajax('/translator/translate', {
     type: 'POST',
-    data: { post_id: post.get('id') }
+    data: { post_id: post.get('id'), locale: I18n.locale }
   }).then(function(res) {
     post.setProperties({
       "translated_text": res.translation,


### PR DESCRIPTION
Some plugins change the locale using methods other than, or in addition to, the user-selected locale. This is a simple change that passes the current Javascript I18n.locale along with the Ajax request to ensure that the backend locale matches the front end when necessary. This should be a non-breaking change, and most people will see no behavior change whatsoever.
