### PR TITLE
Add norwegian, estonian and latvian language support to google backend

### DIFF
--- a/services/discourse_translator/google.rb
+++ b/services/discourse_translator/google.rb
@@ -30,6 +30,8 @@ module DiscourseTranslator
       ru: 'ru',
       sv: 'sv',
       uk: 'uk',
+      lv: 'lv',
+      et: 'et',
       zh_CN: 'zh-CN',
       zh_TW: 'zh-TW',
       tr_TR: 'tr',

--- a/services/discourse_translator/google.rb
+++ b/services/discourse_translator/google.rb
@@ -38,6 +38,7 @@ module DiscourseTranslator
       pt_BR: 'pt',
       pl_PL: 'pl',
       no_NO: 'no',
+      nb_NO: 'no',
       fa_IR: 'fa'
     }
 


### PR DESCRIPTION
Hi,

I added three entries to `google.rb` `SUPPORTED_LANG`. The first was new norwegian locale mapping `nb_NO => 'no'`. The `SUPPORTED_LANG` already had entry for norwegian, but it was `no_NO => 'no'`. If I understand correctly, that locale is deprecated and discourse uses the new `nb_NO` locale.

The two other entries in `SUPPORTED_LANG` are estonian and latvian locale mappings. Google translate API seems to support both of those languages but the mappings were missing from `google.rb`.