### PR TITLE
FIX: Remove update_attributes! which is deprecated in Rails 6.0.0

### DIFF
--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Post do
     end
 
     it 'should reset custom fields when post has been updated' do
-      post.update_attributes!(raw: 'this is an updated post')
+      post.update!(raw: 'this is an updated post')
 
       expect(
         post.custom_fields[::DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]


### PR DESCRIPTION
An easy fix to remove the warning in Rails 6.0.0