### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -64,7 +64,7 @@ after_initialize do
   require_dependency "jobs/base"
 
   module ::Jobs
-    class TranslatorMigrateToAzurePortal < Jobs::Onceoff
+    class TranslatorMigrateToAzurePortal < ::Jobs::Onceoff
       def execute_onceoff(args)
         ["translator_client_id", "translator_client_secret"].each do |name|
 
@@ -95,7 +95,7 @@ after_initialize do
       end
     end
 
-    class DetectTranslation < Jobs::Base
+    class DetectTranslation < ::Jobs::Base
       sidekiq_options retry: false
 
       def execute(args)


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364