### PR TITLE
FIX: Microsoft translator limit is 5000 characters

### DIFF
--- a/services/discourse_translator/microsoft.rb
+++ b/services/discourse_translator/microsoft.rb
@@ -11,7 +11,7 @@ module DiscourseTranslator
     DETECT_URI = "https://api.cognitive.microsofttranslator.com/detect"
     ISSUE_TOKEN_URI = "https://api.cognitive.microsoft.com/sts/v1.0/issueToken"
 
-    LENGTH_LIMIT = 10_000
+    LENGTH_LIMIT = 5_000
 
     SUPPORTED_LANG = {
       en: 'en',


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/cognitive-services/translator/request-limits

related to https://meta.discourse.org/t/translate-button-unable-to-translate-one-post-popup-error-the-field-text-must-be-a-string-or-array-type-with-a-maximum-length-of-5000/132083/10