### PR TITLE
FEATURE: Add support for Cognitive Service’s multi-service resource.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,6 +3,7 @@ en:
     translator_enabled: "Allow inline translation of posts."
     translator: "The provider of the translation service."
     translator_azure_subscription_key: "Azure Subscription Key"
+    translator_azure_region: "Azure Region"
     translator_google_api_key: "Google API Key"
     translator_yandex_api_key: "Yandex API Key"
   translator:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,35 @@ plugins:
       - Yandex
   translator_azure_subscription_key:
     default: ''
+  translator_azure_region:
+    default: 'global'
+    client: true
+    type: enum
+    choices: # Valid choices retrieved from https://docs.microsoft.com/en-us/azure/cognitive-services/translator/reference/v3-0-reference#authenticating-with-a-multi-service-resource
+      - global
+      - australiaeast
+      - brazilsouth
+      - canadacentral
+      - centralindia
+      - centralus
+      - centraluseuap
+      - eastasia
+      - eastus
+      - eastus2
+      - francecentral
+      - japaneast
+      - japanwest
+      - koreacentral
+      - northcentralus
+      - northeurope
+      - southafricanort
+      - southcentralus
+      - southeastasia
+      - uksouth
+      - westcentralus
+      - westeurope
+      - westus
+      - westus2
   translator_google_api_key:
     default: ''
   translator_yandex_api_key:


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/azure/cognitive-services/translator/reference/v3-0-reference#authenticating-with-a-multi-service-resource when a multi-service secret key is used, we have to retrieve the access_token from a different endpoint 

> Regional or Multi-Service | https://<your-region>.api.cognitive.microsoft.com/sts/v1.0/issueToken

This PR provides a site setting for the user to select the region of their azure subscription key.