### PR TITLE
FIX: POST instead of GET when interacting with google translation api.

### DIFF
--- a/services/discourse_translator/microsoft.rb
+++ b/services/discourse_translator/microsoft.rb
@@ -85,7 +85,7 @@ module DiscourseTranslator
 
     def self.detect(post)
       post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] ||= begin
-        text = post.raw.truncate(LENGTH_LIMIT)
+        text = post.raw.truncate(LENGTH_LIMIT, omission: nil)
 
         body = [
           { "Text" => text }


### PR DESCRIPTION
The docs now recommends `POST`: `POST https://translation.googleapis.com/language/translate/v2/detect`

This fixes the error message we were seeing in production: `Your client has issued a malformed or illegal request.`