### PR TITLE
DEV: un-bump migration versions

### DIFF
--- a/db/post_migrate/20210429154318_remove_empty_translation_custom_fields.rb
+++ b/db/post_migrate/20210429154318_remove_empty_translation_custom_fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveEmptyTranslationCustomFields < ActiveRecord::Migration[6.1]
+class RemoveEmptyTranslationCustomFields < ActiveRecord::Migration[6.0]
   def up
     execute <<~SQL
       DELETE FROM post_custom_fields


### PR DESCRIPTION
Allows migrations to work with older versions of Discourse, pre 6.1 bump