### PR TITLE
Microsoft translator character limit is (now) 10000 characters

### DIFF
--- a/services/discourse_translator/microsoft.rb
+++ b/services/discourse_translator/microsoft.rb
@@ -11,7 +11,7 @@ module DiscourseTranslator
     DETECT_URI = "https://api.cognitive.microsofttranslator.com/detect"
     ISSUE_TOKEN_URI = "https://api.cognitive.microsoft.com/sts/v1.0/issueToken"
 
-    LENGTH_LIMIT = 5_000
+    LENGTH_LIMIT = 10_000
 
     SUPPORTED_LANG = {
       en: 'en',


### PR DESCRIPTION
I was looking at #26 and the source for the 5000 character limit mentioned in that PR (https://docs.microsoft.com/en-us/azure/cognitive-services/translator/request-limits) now lists 10000 characters for `translate` and 50000 for `detect`.

![image](https://user-images.githubusercontent.com/4661658/163491282-4308741c-a855-4b66-96c1-ed6a791a2f5d.png)
