### PR TITLE
FIX: Increase Microsoft max character limit to new limit

### DIFF
--- a/services/discourse_translator/microsoft.rb
+++ b/services/discourse_translator/microsoft.rb
@@ -11,7 +11,7 @@ module DiscourseTranslator
     DETECT_URI = "https://api.cognitive.microsofttranslator.com/detect"
     ISSUE_TOKEN_URI = "https://api.cognitive.microsoft.com/sts/v1.0/issueToken"
 
-    LENGTH_LIMIT = 10_000
+    LENGTH_LIMIT = 50_000
 
     # Hash which maps Discourse's locale code to Microsoft Translator's language code found in
     # https://docs.microsoft.com/en-us/azure/cognitive-services/translator/language-support


### PR DESCRIPTION
The 10,000 limit was increased in May 2022 to 50,000 characters. Reference: https://github.com/MicrosoftDocs/azure-docs/pull/92561

Signed-off-by: Grant Slater <github@firefishy.com>