### PR TITLE
FEATURE: added restrict_translation_groups to limit posts translation by groups

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-translate-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-translate-button.js.es6
@@ -26,6 +26,16 @@ function initializeTranslation(api) {
     return;
   }
 
+  let nonRestrictedGroups =
+    siteSettings.restrict_translation_by_group.split("|");
+  let authorized_group = currentUser.groups.any((group) =>
+    nonRestrictedGroups.includes(group.id.toString())
+  );
+
+  if (!authorized_group) {
+    return;
+  }
+
   api.includePostAttributes(
     "can_translate",
     "translated_text",

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,3 +82,7 @@ plugins:
     default: ''
   max_translations_per_minute:
     default: 3
+  restrict_translation_by_group:
+    default: "11" # default group trust_level_1
+    client: true
+    type: group_list

--- a/spec/controllers/translator_controller_spec.rb
+++ b/spec/controllers/translator_controller_spec.rb
@@ -8,9 +8,21 @@ RSpec.describe ::DiscourseTranslator::TranslatorController do
   before do
     SiteSetting.translator_enabled = true
     SiteSetting.translator = "Microsoft"
+    SiteSetting.restrict_translation_by_group = "#{Group.find_by(name: "trust_level_1").id}"
   end
 
   after { SiteSetting.translator_enabled = false }
+
+  shared_examples "translation_successful" do
+    it "returns the translated text" do
+      DiscourseTranslator::Microsoft.expects(:translate).with(reply).returns(%w[ja ニャン猫])
+
+      post :translate, params: { post_id: reply.id }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq({ translation: "ニャン猫", detected_lang: "ja" }.to_json)
+    end
+  end
 
   describe "#translate" do
     describe "anon user" do
@@ -21,9 +33,13 @@ RSpec.describe ::DiscourseTranslator::TranslatorController do
     end
 
     describe "logged in user" do
-      let!(:user) { log_in }
+      let!(:user) do
+        user = log_in
+        user.group_users << Fabricate(:group_user, user: user, group: Group[:trust_level_1])
+        user
+      end
 
-      describe "when disabled" do
+      describe "when config translator_enabled disabled" do
         before { SiteSetting.translator_enabled = false }
 
         it "should deny request to translate" do
@@ -47,6 +63,7 @@ RSpec.describe ::DiscourseTranslator::TranslatorController do
         end
 
         it "raises the right error when post is inaccessible" do
+          user = log_in
           mypost = Fabricate(:private_message_post)
           post :translate, params: { post_id: mypost.id }, format: :json
           expect(response.status).to eq(403)
@@ -62,13 +79,25 @@ RSpec.describe ::DiscourseTranslator::TranslatorController do
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
-        it "returns the translated text" do
-          DiscourseTranslator::Microsoft.expects(:translate).with(reply).returns(%w[ja ニャン猫])
+        describe "all groups can translate" do
+          include_examples "translation_successful"
+        end
 
-          post :translate, params: { post_id: reply.id }, format: :json
+        describe "user is in a allowlisted group" do
+          before do
+            SiteSetting.restrict_translation_by_group =
+              "#{Group.find_by(name: "admins").id}|not_in_the_list"
+          end
+          let!(:user) { log_in :admin }
+          include_examples "translation_successful"
+        end
 
-          expect(response).to have_http_status(:ok)
-          expect(response.body).to eq({ translation: "ニャン猫", detected_lang: "ja" }.to_json)
+        describe "user is not in a allowlisted group" do
+          before { SiteSetting.restrict_translation_by_group = "not_in_the_list" }
+          it "should deny request to translate" do
+            response = post :translate, params: { post_id: 1 }, format: :json
+            expect(response).to have_http_status(:bad_request)
+          end
         end
       end
     end


### PR DESCRIPTION
Limit the posts to be translated by a certain group (admins/mods, etc.) so that larger forums aren’t rate limited by translation requests, and the translation requests are controlled for only important posts.

This will allow for a team that is mainly in a single locale to have their announcement and response content be shared and read across locales without having to worry about a translation pipeline