### PR TITLE
FEATURE: Support custom endpoints for Microsoft provider

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,6 +11,7 @@ en:
     translator_aws_key_id: "AWS Key ID"
     translator_aws_secret_access: "AWS secret access key"
     translator_aws_iam_role: "AWS IAM Role"
+    translator_azure_custom_domain: "Required if using a Virtual Network or Firewall for Azure Cognitive Services"
   translator:
     failed: "The translator is unable to translate this language."
     not_supported: "This language is not supported by the translator."
@@ -18,3 +19,4 @@ en:
 
     microsoft:
       missing_token: "The translator was unable to retrieve a valid token."
+      missing_key: "No Azure Subscription Key provided."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,8 @@ plugins:
       - westeurope
       - westus
       - westus2
+  translator_azure_custom_domain:
+    default: ""
   translator_aws_region:
     default: 'us-east-1'
     client: true

--- a/spec/services/microsoft_spec.rb
+++ b/spec/services/microsoft_spec.rb
@@ -5,104 +5,58 @@ require "rails_helper"
 RSpec.describe DiscourseTranslator::Microsoft do
   after { Discourse.redis.del(described_class.cache_key) }
 
-  describe ".access_token" do
-    before do
-      SiteSetting.translator_azure_subscription_key = "some key"
-      SiteSetting.translator_azure_region = "global"
-    end
-
-    it "should return the access_token and cache it" do
-      stub_request(
-        :post,
-        "https://api.cognitive.microsoft.com/sts/v1.0/issueToken?Subscription-Key=some%20key",
-      ).to_return(status: 200, body: "some_token")
-
-      expect(described_class.access_token).to eq("some_token")
-      expect(Discourse.redis.get(described_class.cache_key)).to eq("some_token")
-      expect(Discourse.redis.ttl(described_class.cache_key).present?).to eq(true)
-    end
-
-    describe "when access_token is not valid" do
-      it "should raise the right error" do
-        stub_request(
-          :post,
-          "https://api.cognitive.microsoft.com/sts/v1.0/issueToken?Subscription-Key=some%20key",
-        ).to_return(
-          status: 401,
-          body:
-            # rubocop:disable Layout/LineLength
-            "{\"error\":{\"code\":\"401\",\"message\": \"Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource.\"}}",
-          # rubocop:enable Layout/LineLength
-        )
-
-        expect { described_class.access_token }.to raise_error(
-          DiscourseTranslator::TranslatorError,
-          /401/,
-        )
-      end
-    end
-
-    describe "when azure region is specified" do
-      before { SiteSetting.translator_azure_region = "eastus2" }
-
-      it "should get access token from the right endpoint" do
-        stub_request(
-          :post,
-          "https://eastus2.api.cognitive.microsoft.com/sts/v1.0/issueToken?Subscription-Key=some%20key",
-        ).to_return(status: 200, body: "some_token")
-
-        expect(described_class.access_token).to eq("some_token")
-      end
-    end
-  end
-
   describe ".detect" do
     let(:post) { Fabricate(:post) }
+    let(:detected_lang) { "en" }
 
-    let(:url) do
-      uri = URI(described_class::DETECT_URI)
+    def detect_endpoint
+      uri = URI(described_class.detect_endpoint)
       uri.query = URI.encode_www_form(described_class.default_query)
       uri.to_s
     end
 
-    let(:detected_lang) { "en" }
+    before { SiteSetting.translator_azure_subscription_key = "e1bba646088021aaf1ef972a48" }
 
-    before do
-      Discourse.redis.set(described_class.cache_key, "12345")
+    shared_examples "language detected" do
+      it "stores detected language in a custom field" do
+        described_class.detect(post)
 
-      stub_request(:post, url).to_return(
-        status: 200,
-        body: [{ "language" => detected_lang }].to_json,
-      )
-    end
-
-    it "should store the detected language in a custom field" do
-      described_class.detect(post)
-
-      2.times do
         expect(post.custom_fields[::DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).to eq(
           detected_lang,
         )
       end
+    end
+
+    context "with a custom endpoint" do
+      before do
+        SiteSetting.translator_azure_custom_domain = "translator19191"
+
+        stub_request(:post, detect_endpoint).to_return(
+          status: 200,
+          body: [{ "language" => detected_lang }].to_json,
+        )
+      end
+
+      include_examples "language detected"
+    end
+
+    context "without a custom endpoint" do
+      before do
+        stub_request(:post, detect_endpoint).to_return(
+          status: 200,
+          body: [{ "language" => detected_lang }].to_json,
+        )
+      end
+
+      include_examples "language detected"
     end
   end
 
   describe ".translate" do
     let(:post) { Fabricate(:post) }
 
-    before do
-      Discourse.redis.set(described_class.cache_key, "12345")
-      post.custom_fields = { DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD => "en" }
-      post.save_custom_fields
-    end
-
-    after { Discourse.redis.del(described_class.cache_key) }
-
-    it "should work" do
-      I18n.locale = "de"
-
-      uri = URI(described_class::TRANSLATE_URI)
-
+    def translate_endpoint
+      uri = URI(described_class.translate_endpoint)
       uri.query =
         URI.encode_www_form(
           described_class.default_query.merge(
@@ -112,70 +66,93 @@ RSpec.describe DiscourseTranslator::Microsoft do
           ),
         )
 
-      stub_request(:post, uri.to_s).to_return(
-        status: 200,
-        body: [{ "translations" => [{ "text" => "some de text" }] }].to_json,
-      )
-
-      expect(described_class.translate(post)).to eq(["en", "some de text"])
+      uri.to_s
     end
 
-    it "should return the right value when post has already been translated" do
-      I18n.locale = "en"
-
-      post.custom_fields = {
-        DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD => "tr",
-        DiscourseTranslator::TRANSLATED_CUSTOM_FIELD => {
-          "en" => "some english text",
-        },
-      }
-
+    before do
+      post.custom_fields = { DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD => "en" }
       post.save_custom_fields
-
-      expect(described_class.translate(post)).to eq(["tr", "some english text"])
+      SiteSetting.translator_azure_subscription_key = "e1bba646088021aaf1ef972a48"
     end
 
-    it "raises an error if detected language of the post is not supported" do
-      post.custom_fields = { DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD => "donkey" }
-      post.save_custom_fields
+    shared_examples "post translated" do
+      it "translates post" do
+        I18n.locale = "de"
 
-      expect { described_class.translate(post) }.to raise_error(
-        DiscourseTranslator::TranslatorError,
-        I18n.t("translator.failed"),
-      )
+        stub_request(:post, translate_endpoint).to_return(
+          status: 200,
+          body: [{ "translations" => [{ "text" => "some de text" }] }].to_json,
+        )
+
+        expect(described_class.translate(post)).to eq(["en", "some de text"])
+      end
     end
 
-    it "raises an error if the post is too long to be translated" do
-      post.update_columns(cooked: "*" * (DiscourseTranslator::Microsoft::LENGTH_LIMIT + 1))
+    context "with a custom endpoint" do
+      before { SiteSetting.translator_azure_custom_domain = "translator19191" }
 
-      expect { described_class.translate(post) }.to raise_error(
-        DiscourseTranslator::TranslatorError,
-        I18n.t("translator.too_long"),
-      )
+      include_examples "post translated"
     end
 
-    it "raises an error on failure" do
-      stub_request(
-        :post,
-        "https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=en&textType=html&to=en",
-      ).with(
-        body: "[{\"Text\":\"\\u003cp\\u003eHello world\\u003c/p\\u003e\"}]",
-        headers: {
-          "Authorization" => "Bearer 12345",
-          "Content-Type" => "application/json",
-          "Host" => "api.cognitive.microsofttranslator.com",
-        },
-      ).to_return(
-        status: 400,
-        body: {
-          error: "something went wrong",
-          error_description: "you passed in a wrong param",
-        }.to_json,
-      )
+    context "without a custom endpoint" do
+      include_examples "post translated"
 
-      expect { described_class.translate(post) }.to raise_error(
-        DiscourseTranslator::TranslatorError,
-      )
+      it "returns stored translation if post has already been translated" do
+        I18n.locale = "en"
+
+        post.custom_fields = {
+          DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD => "tr",
+          DiscourseTranslator::TRANSLATED_CUSTOM_FIELD => {
+            "en" => "some english text",
+          },
+        }
+
+        post.save_custom_fields
+
+        expect(described_class.translate(post)).to eq(["tr", "some english text"])
+      end
+
+      it "raises an error if detected language of the post is not supported" do
+        post.custom_fields = { DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD => "donkey" }
+        post.save_custom_fields
+
+        expect { described_class.translate(post) }.to raise_error(
+          DiscourseTranslator::TranslatorError,
+          I18n.t("translator.failed"),
+        )
+      end
+
+      it "raises an error if the post is too long to be translated" do
+        post.update_columns(cooked: "*" * (DiscourseTranslator::Microsoft::LENGTH_LIMIT + 1))
+
+        expect { described_class.translate(post) }.to raise_error(
+          DiscourseTranslator::TranslatorError,
+          I18n.t("translator.too_long"),
+        )
+      end
+
+      it "raises an error on failure" do
+        stub_request(
+          :post,
+          "https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=en&textType=html&to=en",
+        ).with(
+          body: "[{\"Text\":\"\\u003cp\\u003eHello world\\u003c/p\\u003e\"}]",
+          headers: {
+            "Ocp-Apim-Subscription-Key" => SiteSetting.translator_azure_subscription_key,
+            "Content-Type" => "application/json",
+          },
+        ).to_return(
+          status: 400,
+          body: {
+            error: "something went wrong",
+            error_description: "you passed in a wrong param",
+          }.to_json,
+        )
+
+        expect { described_class.translate(post) }.to raise_error(
+          DiscourseTranslator::TranslatorError,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, we call the translator service via the standard global and regional endpoints using token based authentication. This fails when a Virtual Network/Firewall is enabled.

Once enabled, calls must be made to a custom endpoint using a subscription key based authentication strategy.

This change adds support for custom endpoints and moves to a subscription key based authentication strategy for all endpoint types.