### PR TITLE
FIX: typo for Serbian Cyrillic breaks its translation

### DIFF
--- a/services/discourse_translator/microsoft.rb
+++ b/services/discourse_translator/microsoft.rb
@@ -76,7 +76,7 @@ module DiscourseTranslator
       sk: "sk",
       sl: "sl",
       sq: "sq",
-      sr: "sr-Cryl",
+      sr: "sr-Cyrl",
       sv: "sv",
       sw: "sw",
       ta: "ta",


### PR DESCRIPTION
It should help with Serbian Cyrillic translation working, see https://community.openstreetmap.org/t/serbian-cyrillic-is-not-being-translated/9115 for original report - i.e. it fails with _"An error occurred: The translator is unable to translate this language."_ even if https://www.bing.com/translator has no problem with translating it manually.