### PR TITLE
DEV: Rename translator_azure_custom_domain Site Setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,7 +11,7 @@ en:
     translator_aws_key_id: "AWS Key ID"
     translator_aws_secret_access: "AWS secret access key"
     translator_aws_iam_role: "AWS IAM Role"
-    translator_azure_custom_domain: "Required if using a Virtual Network or Firewall for Azure Cognitive Services"
+    translator_azure_custom_subdomain: "Required if using a Virtual Network or Firewall for Azure Cognitive Services. Note: Only enter the custom subdomain not the full custom endpoint."
   translator:
     failed: "The translator is unable to translate this language."
     not_supported: "This language is not supported by the translator."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,7 +42,7 @@ plugins:
       - westeurope
       - westus
       - westus2
-  translator_azure_custom_domain:
+  translator_azure_custom_subdomain:
     default: ""
   translator_aws_region:
     default: 'us-east-1'

--- a/db/migrate/20230323110557_rename_translator_azure_custom_domain_site_setting.rb
+++ b/db/migrate/20230323110557_rename_translator_azure_custom_domain_site_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RenameTranslatorAzureCustomDomainSiteSetting < ActiveRecord::Migration[7.0]
+  def up
+    execute "UPDATE site_settings SET name = 'translator_azure_custom_subdomain' WHERE name = 'translator_azure_custom_domain'"
+  end
+
+  def down
+    execute "UPDATE site_settings SET name = 'translator_azure_custom_domain' WHERE name =  'translator_azure_custom_subdomain'"
+  end
+end

--- a/services/discourse_translator/microsoft.rb
+++ b/services/discourse_translator/microsoft.rb
@@ -144,7 +144,7 @@ module DiscourseTranslator
     end
 
     def self.custom_base_endpoint
-      "https://#{SiteSetting.translator_azure_custom_domain}.#{CUSTOM_URI_SUFFIX}"
+      "https://#{SiteSetting.translator_azure_custom_subdomain}.#{CUSTOM_URI_SUFFIX}"
     end
 
     def self.custom_detect_endpoint
@@ -156,7 +156,7 @@ module DiscourseTranslator
     end
 
     def self.custom_endpoint?
-      SiteSetting.translator_azure_custom_domain.present?
+      SiteSetting.translator_azure_custom_subdomain.present?
     end
 
     def self.locale

--- a/spec/services/microsoft_spec.rb
+++ b/spec/services/microsoft_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DiscourseTranslator::Microsoft do
 
     context "with a custom endpoint" do
       before do
-        SiteSetting.translator_azure_custom_domain = "translator19191"
+        SiteSetting.translator_azure_custom_subdomain = "translator19191"
 
         stub_request(:post, detect_endpoint).to_return(
           status: 200,
@@ -89,7 +89,7 @@ RSpec.describe DiscourseTranslator::Microsoft do
     end
 
     context "with a custom endpoint" do
-      before { SiteSetting.translator_azure_custom_domain = "translator19191" }
+      before { SiteSetting.translator_azure_custom_subdomain = "translator19191" }
 
       include_examples "post translated"
     end


### PR DESCRIPTION
Update the site setting along with it's description to convey the fact that only the subdomain bit is required.