### PR TITLE
FIX: Serbian is digraphic while Microsoft API treats as separate languages

### DIFF
--- a/services/discourse_translator/microsoft.rb
+++ b/services/discourse_translator/microsoft.rb
@@ -73,6 +73,7 @@ module DiscourseTranslator
       sl: "sl",
       sq: "sq",
       sr: "sr-Cyrl",
+      "sr-Latn": "sr-Latn",
       sv: "sv",
       sw: "sw",
       ta: "ta",


### PR DESCRIPTION
Serbian is a digraphic language with both the Latin and Cyrillic forms are common and seemingly used interchangeably.
Discourse's Serbian translation uses both Latin (widely) and Cyrillic (mostly limited to dates etc).

Without this workaround when the Microsoft Translate API detects `sr-Latn` the `raise TranslatorError.new(I18n.t("translator.failed"))` is thrown because `sr-Latn` is not matched. This adds an inelegant  workaround by adding `sr-Latn` to supported list. `sr-Latn` isn't directly a supported Discourse i18n.