### PR TITLE
FIX: Fix for anon users visiting posts when the plugin is enabled

### DIFF
--- a/lib/discourse_translator/guardian_extension.rb
+++ b/lib/discourse_translator/guardian_extension.rb
@@ -3,6 +3,7 @@ module DiscourseTranslator::GuardianExtension
   def user_group_allowed?
     authorized_groups = SiteSetting.restrict_translation_by_group.split("|").map(&:to_i)
 
+    return false if !current_user
     user_groups = current_user.groups.pluck :id
     authorized = authorized_groups.intersection user_groups
     !authorized.empty?

--- a/spec/lib/guardian_extension_spec.rb
+++ b/spec/lib/guardian_extension_spec.rb
@@ -23,5 +23,11 @@ describe DiscourseTranslator::GuardianExtension do
 
       expect(guardian.user_group_allowed?).to eq(false)
     end
+
+    it "returns false when the user is not logged in" do
+      SiteSetting.restrict_translation_by_group = "not_in_the_list"
+      non_logged_guardian = Guardian.new
+      expect(non_logged_guardian.user_group_allowed?).to eq(false)
+    end
   end
 end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -19,28 +19,28 @@ RSpec.describe PostSerializer do
       end
       let(:serializer) { PostSerializer.new(post, scope: Guardian.new(user)) }
 
-      describe "when user is in a allowlisted group"
-      before do
-        SiteSetting.restrict_translation_by_group =
-          "#{Group.find_by(name: user.groups.first.name).id}|not_in_the_list"
-      end
-      describe "when post detected lang does not match user's locale" do
+      describe "when user is in a allowlisted group" do
         before do
-          post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"
-          post.save
+          SiteSetting.restrict_translation_by_group =
+            "#{Group.find_by(name: user.groups.first.name).id}|not_in_the_list"
+        end
+        describe "when post detected lang does not match user's locale" do
+          before do
+            post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"
+            post.save
+          end
+
+          it { expect(serializer.can_translate).to eq(true) }
         end
 
-        it { expect(serializer.can_translate).to eq(true) }
-      end
-
-      describe "when post detected lang matches user's locale" do
-        before do
-          post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "en"
-          post.save
+        describe "when post detected lang matches user's locale" do
+          before do
+            post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "en"
+            post.save
+          end
+          it { expect(serializer.can_translate).to eq(false) }
         end
-        it { expect(serializer.can_translate).to eq(false) }
       end
-
       describe "when user is not in a allowlisted group" do
         before do
           post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -4,12 +4,6 @@ require "rails_helper"
 
 RSpec.describe PostSerializer do
   let(:post) { Fabricate(:post) }
-  let!(:user) do
-    user = Fabricate(:user, locale: "en")
-    user.group_users << Fabricate(:group_user, user: user, group: Group[:trust_level_1])
-    user
-  end
-  let(:serializer) { PostSerializer.new(post, scope: Guardian.new(user)) }
 
   before do
     SiteSetting.translator_enabled = true
@@ -17,38 +11,60 @@ RSpec.describe PostSerializer do
   end
 
   describe "#can_translate" do
-    describe "when user is in a allowlisted group"
-    before do
-      SiteSetting.restrict_translation_by_group =
-        "#{Group.find_by(name: user.groups.first.name).id}|not_in_the_list"
+    describe "logged in user" do
+      let(:user) do
+        user = Fabricate(:user, locale: "en")
+        user.group_users << Fabricate(:group_user, user: user, group: Group[:trust_level_1])
+        user
+      end
+      let(:serializer) { PostSerializer.new(post, scope: Guardian.new(user)) }
+
+      describe "when user is in a allowlisted group"
+      before do
+        SiteSetting.restrict_translation_by_group =
+          "#{Group.find_by(name: user.groups.first.name).id}|not_in_the_list"
+      end
+      describe "when post detected lang does not match user's locale" do
+        before do
+          post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"
+          post.save
+        end
+
+        it { expect(serializer.can_translate).to eq(true) }
+      end
+
+      describe "when post detected lang matches user's locale" do
+        before do
+          post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "en"
+          post.save
+        end
+        it { expect(serializer.can_translate).to eq(false) }
+      end
+
+      describe "when user is not in a allowlisted group" do
+        before do
+          post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"
+          post.save
+          SiteSetting.restrict_translation_by_group = "not_in_the_list"
+        end
+
+        it "should not translate even if the post detected lang does not match the user's locale" do
+          expect(serializer.can_translate).to eq(false)
+        end
+      end
     end
-    describe "when post detected lang does not match user's locale" do
+
+    describe "when user is not logged in" do
+      let(:serializer) { PostSerializer.new(post, scope: Guardian.new) }
       before do
         post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"
         post.save
+        SiteSetting.restrict_translation_by_group = "11|not_in_the_list"
       end
 
-      it { expect(serializer.can_translate).to eq(true) }
-    end
-
-    describe "when post detected lang matches user's locale" do
-      before do
-        post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "en"
-        post.save
+      it "should not translate" do
+        expect(serializer.can_translate).to eq(false)
       end
-      it { expect(serializer.can_translate).to eq(false) }
-    end
-  end
-
-  describe "when user is not in a allowlisted group" do
-    before do
-      post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"
-      post.save
-      SiteSetting.restrict_translation_by_group = "not_in_the_list"
-    end
-
-    it "should not translate even if the post detected lang does not match the user's locale" do
-      expect(serializer.can_translate).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Fix for [500 error - NoMethodError (undefined method `groups’ for nil:NilClass)](https://meta.discourse.org/t/oops-500-error-nomethoderror-undefined-method-groups-for-nil-nilclass/265062). It was happening when trying to visit a post while there was no user logged in and the plugin is enabled.