### PR TITLE
FEATURE: Restrict translations by poster group

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -13,6 +13,7 @@ en:
     translator_aws_iam_role: "AWS IAM Role"
     translator_azure_custom_subdomain: "Required if using a Virtual Network or Firewall for Azure Cognitive Services. Note: Only enter the custom subdomain not the full custom endpoint."
     restrict_translation_by_group: "Only allowlisted groups can translate"
+    restrict_translation_by_poster_group: "Only allow translation of posts made by allowlisted users"
   translator:
     failed: "The translator is unable to translate this language."
     not_supported: "This language is not supported by the translator."
@@ -22,4 +23,5 @@ en:
       missing_token: "The translator was unable to retrieve a valid token."
       missing_key: "No Azure Subscription Key provided."
   not_in_group: 
-    title_translation: "You don't belong to a group allowed to translate"
+    user_not_in_group: "You don't belong to a group allowed to translate."
+    poster_not_in_group: "Post wasn't made by an user in a allowlisted group. If empty it is disabled."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -88,3 +88,7 @@ plugins:
     default: "11" # default group trust_level_1
     client: true
     type: group_list
+  restrict_translation_by_poster_group:
+    default: "" 
+    client: true
+    type: group_list

--- a/lib/discourse_translator/guardian_extension.rb
+++ b/lib/discourse_translator/guardian_extension.rb
@@ -2,9 +2,22 @@
 module DiscourseTranslator::GuardianExtension
   def user_group_allowed?
     authorized_groups = SiteSetting.restrict_translation_by_group.split("|").map(&:to_i)
+    
+    authorized? current_user, authorized_groups
+  end
 
-    return false if !current_user
-    user_groups = current_user.groups.pluck :id
+  def post_group_allowed? (post)
+    authorized_poster_groups = SiteSetting.restrict_translation_by_poster_group.split("|").map(&:to_i)
+    return true if authorized_poster_groups.empty?
+    
+    poster = User.find post.user_id
+    authorized? poster, authorized_poster_groups
+  end
+
+  def authorized? (user, authorized_groups)
+    return false if !user
+    
+    user_groups = user.groups.pluck :id
     authorized = authorized_groups.intersection user_groups
     !authorized.empty?
   end

--- a/lib/discourse_translator/guardian_extension.rb
+++ b/lib/discourse_translator/guardian_extension.rb
@@ -2,21 +2,22 @@
 module DiscourseTranslator::GuardianExtension
   def user_group_allowed?
     authorized_groups = SiteSetting.restrict_translation_by_group.split("|").map(&:to_i)
-    
+
     authorized? current_user, authorized_groups
   end
 
-  def post_group_allowed? (post)
-    authorized_poster_groups = SiteSetting.restrict_translation_by_poster_group.split("|").map(&:to_i)
+  def post_group_allowed?(post)
+    authorized_poster_groups =
+      SiteSetting.restrict_translation_by_poster_group.split("|").map(&:to_i)
     return true if authorized_poster_groups.empty?
-    
+
     poster = User.find post.user_id
     authorized? poster, authorized_poster_groups
   end
 
-  def authorized? (user, authorized_groups)
+  def authorized?(user, authorized_groups)
     return false if !user
-    
+
     user_groups = user.groups.pluck :id
     authorized = authorized_groups.intersection user_groups
     !authorized.empty?

--- a/spec/lib/guardian_extension_spec.rb
+++ b/spec/lib/guardian_extension_spec.rb
@@ -3,31 +3,87 @@
 require "rails_helper"
 
 describe DiscourseTranslator::GuardianExtension do
-  describe "#user_group_allowed?" do
-    let!(:user) do
+  shared_examples "post_group_allowed" do
+    it "returns true when the post was made by an user in a allowlisted group" do
+      SiteSetting.restrict_translation_by_poster_group = "#{Group[:trust_level_1].id}"
+
+      expect(guardian.post_group_allowed?(post)).to eq(true)
+    end
+
+    it "returns true when no group has selected in settings" do
+      SiteSetting.restrict_translation_by_poster_group = ""
+
+      expect(guardian.post_group_allowed?(post)).to eq(true)
+    end
+  end
+
+  shared_examples "post_group_not_allowed" do
+    it "returns true when the post was made by an user not in a allowlisted group" do
+      SiteSetting.restrict_translation_by_poster_group = "#{Group[:trust_level_4].id}"
+
+      expect(guardian.post_group_allowed?(post)).to eq(false)
+    end
+  end
+
+  describe "anon user" do
+    let!(:guardian) { Guardian.new }
+    let(:post) { Fabricate(:post) }
+    describe "#user_group_allowed?" do
+      it "returns false when the user is not logged in" do
+        SiteSetting.restrict_translation_by_group = "not_in_the_list"
+
+        expect(guardian.user_group_allowed?).to eq(false)
+      end
+    end
+
+    describe "#post_group_allowed?" do
+      include_examples "post_group_not_allowed"
+    end
+
+    describe "#authorized?" do
+        it "returns false with authorized groups" do 
+          expect(guardian.authorized?(nil, ['authorized_group'])).to eq(false)
+        end
+    end
+  end
+
+  describe "logged in user" do
+    let(:user) do
       user = Fabricate(:user)
       user.group_users << Fabricate(:group_user, user: user, group: Group[:trust_level_1])
       user
     end
-    let!(:guardian) { Guardian.new(user) }
+    let(:guardian) { Guardian.new(user) }
+    let(:post) { Fabricate(:post, user: user) }
 
-    it "returns true when the user is in a allowlisted group" do
-      SiteSetting.restrict_translation_by_group =
-        "#{Group.find_by(name: user.groups.first.name).id}|not_in_the_list"
+    describe "#user_group_allowed?" do
+      it "returns true when the user is in a allowlisted group" do
+        SiteSetting.restrict_translation_by_group =
+          "#{Group.find_by(name: user.groups.first.name).id}|not_in_the_list"
 
-      expect(guardian.user_group_allowed?).to eq(true)
+        expect(guardian.user_group_allowed?).to eq(true)
+      end
+
+      it "returns false when the user is not in a allowlisted group" do
+        SiteSetting.restrict_translation_by_group = "not_in_the_list"
+
+        expect(guardian.user_group_allowed?).to eq(false)
+      end
     end
 
-    it "returns false when the user is not in a allowlisted group" do
-      SiteSetting.restrict_translation_by_group = "not_in_the_list"
-
-      expect(guardian.user_group_allowed?).to eq(false)
+    describe "#post_group_allowed?" do
+      include_examples "post_group_allowed"
+      include_examples "post_group_not_allowed"
     end
 
-    it "returns false when the user is not logged in" do
-      SiteSetting.restrict_translation_by_group = "not_in_the_list"
-      non_logged_guardian = Guardian.new
-      expect(non_logged_guardian.user_group_allowed?).to eq(false)
+    describe "#authorized?" do
+      it "returns true with user in autorized groups" do
+        expect(guardian.authorized? user, [Group[:trust_level_1].id]).to eq(true)
+      end
+
+      it "returns false with user not in autoried groups" do
+        expect(guardian.authorized? user, ["not_in_the_list"]).to eq(false)
+      end
     end
   end
 end

--- a/spec/lib/guardian_extension_spec.rb
+++ b/spec/lib/guardian_extension_spec.rb
@@ -41,9 +41,9 @@ describe DiscourseTranslator::GuardianExtension do
     end
 
     describe "#authorized?" do
-        it "returns false with authorized groups" do 
-          expect(guardian.authorized?(nil, ['authorized_group'])).to eq(false)
-        end
+      it "returns false with authorized groups" do
+        expect(guardian.authorized?(nil, ["authorized_group"])).to eq(false)
+      end
     end
   end
 

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -10,6 +10,28 @@ RSpec.describe PostSerializer do
     SiteSetting.queue_jobs = true
   end
 
+  shared_examples "detected_lang_does_not_match_user_locale" do
+    describe "when post detected lang does not match user's locale" do
+      before do
+        post_with_user.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"
+        post_with_user.save
+      end
+
+      it { expect(serializer.can_translate).to eq(true) }
+    end
+  end
+
+  shared_examples "detected_lang_match_user_locale" do
+    describe "when post detected lang matches user's locale" do
+      before do
+        post_with_user.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "en"
+        post_with_user.save
+      end
+
+      it { expect(serializer.can_translate).to eq(false) }
+    end
+  end
+
   describe "#can_translate" do
     describe "logged in user" do
       let(:user) do
@@ -17,29 +39,35 @@ RSpec.describe PostSerializer do
         user.group_users << Fabricate(:group_user, user: user, group: Group[:trust_level_1])
         user
       end
-      let(:serializer) { PostSerializer.new(post, scope: Guardian.new(user)) }
+      let(:serializer) { PostSerializer.new(post_with_user, scope: Guardian.new(user)) }
+      let(:post_with_user) { Fabricate(:post, user: user) }
+
+      describe "when poster is in a allowlisted group" do
+        before do
+          SiteSetting.restrict_translation_by_poster_group =
+            "#{User.find(post_with_user.user_id).groups.first.id}"
+        end
+
+        include_examples "detected_lang_does_not_match_user_locale"
+        include_examples "detected_lang_match_user_locale"
+      end
+
+      describe "when poster is not in a allowlisted group" do
+        before do
+          SiteSetting.restrict_translation_by_poster_group = "#{Group[:trust_level_4]}"
+          post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"
+          post.save
+        end
+
+        it { expect(serializer.can_translate).to eq(false) }
+      end
 
       describe "when user is in a allowlisted group" do
         before do
-          SiteSetting.restrict_translation_by_group =
-            "#{Group.find_by(name: user.groups.first.name).id}|not_in_the_list"
+          SiteSetting.restrict_translation_by_group = "#{user.groups.first.id}|not_in_the_list"
         end
-        describe "when post detected lang does not match user's locale" do
-          before do
-            post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "ja"
-            post.save
-          end
-
-          it { expect(serializer.can_translate).to eq(true) }
-        end
-
-        describe "when post detected lang matches user's locale" do
-          before do
-            post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "en"
-            post.save
-          end
-          it { expect(serializer.can_translate).to eq(false) }
-        end
+        include_examples "detected_lang_does_not_match_user_locale"
+        include_examples "detected_lang_match_user_locale"
       end
       describe "when user is not in a allowlisted group" do
         before do


### PR DESCRIPTION
**Context**
The customer wants to limit post translation to only allowing the translation of posts created by users in picked groups. This will only allow the translation of topics deemed important by the customer.

**End Result**
Implemented a `SiteSetting` to control which groups can create posts that will be cleared for translation. Leaving the list empty will allow the translation for posts made by any group.
