### PR TITLE
FIX: Don't attempt to detect language of blank strings

### DIFF
--- a/services/discourse_translator/amazon.rb
+++ b/services/discourse_translator/amazon.rb
@@ -93,10 +93,14 @@ module DiscourseTranslator
     end
 
     def self.detect(post)
+      text = post.cooked.truncate(MAXLENGTH, omission: nil)
+
+      return if text.blank?
+
       detected_lang =
         client.translate_text(
           {
-            text: post.cooked.truncate(MAXLENGTH, omission: nil),
+            text: text,
             source_language_code: "auto",
             target_language_code: SUPPORTED_LANG_MAPPING[I18n.locale],
           },

--- a/spec/services/amazon_spec.rb
+++ b/spec/services/amazon_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe DiscourseTranslator::Amazon do
       post.cooked = rand(36**length).to_s(36)
       expect(described_class.detect(post)).to eq(detected_lang)
     end
+
+    it "should fail graciously when the cooked translated text is blank" do
+      post.cooked = ""
+      expect(described_class.detect(post)).to be_nil
+    end
   end
 
   describe ".translate" do


### PR DESCRIPTION
### What is this change?

We're currently seeing the following exception in production logs:

```
Job exception: text size cannot be zero
```

which is happening when we try to detect language of a blank string.

This change fixes that by returning `nil` instead of issuing a request when that happens.