### PR TITLE
FIX: Amazon text size is 10k bytes

### DIFF
--- a/services/discourse_translator/base.rb
+++ b/services/discourse_translator/base.rb
@@ -52,7 +52,7 @@ module DiscourseTranslator
     def self.get_text(topic_or_post)
       case topic_or_post.class.name
       when "Post"
-        text = topic_or_post.cooked
+        topic_or_post.cooked
       when "Topic"
         topic_or_post.title
       end


### PR DESCRIPTION
The Amazon translate API allows for a text to be up to 10k bytes.

This changes the `MAXLENGTH` constant into the `MAX_BYTES` and uses a `truncate` method that works at the bytes level instead of the character/grapheme level.

Ref - https://meta.discourse.org/t/increase-amazon-translate-limit-to-10-000-characters/304579