### PR TITLE
FIX: Skip translations for empty or small actions posts

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -168,12 +168,11 @@ after_initialize do
   end
 
   add_to_serializer :post, :can_translate do
-    if !(
-         SiteSetting.translator_enabled && scope.user_group_allow_translate? &&
-           scope.poster_group_allow_translate?(object)
-       )
+    return false if !SiteSetting.translator_enabled
+    if !scope.user_group_allow_translate? || !scope.poster_group_allow_translate?(object)
       return false
     end
+    return false if raw.blank? || post_type == Post.types[:small_action]
 
     detected_lang = post_custom_fields[::DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]
 

--- a/spec/jobs/detect_translation_spec.rb
+++ b/spec/jobs/detect_translation_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "aws-sdk-translate"
+
+describe Jobs::DetectTranslation do
+  before do
+    SiteSetting.translator = "Amazon"
+    client = Aws::Translate::Client.new(stub_responses: true)
+    client.stub_responses(
+      :translate_text,
+      { translated_text: "大丈夫", source_language_code: "en", target_language_code: "jp" },
+    )
+    Aws::Translate::Client.stubs(:new).returns(client)
+  end
+
+  it "does not detect translation if translator disabled" do
+    SiteSetting.translator_enabled = false
+
+    post = Fabricate(:post)
+    Jobs::DetectTranslation.new.execute(post_id: post.id)
+
+    expect(post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).to be_nil
+  end
+
+  describe "translator enabled" do
+    before { SiteSetting.translator_enabled = true }
+
+    it "does not detect translation if post does not exist" do
+      post = Fabricate(:post)
+      post.destroy
+
+      Jobs::DetectTranslation.new.execute(post_id: post.id)
+
+      expect(post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).to be_nil
+    end
+
+    it "detects translation" do
+      post = Fabricate(:post, raw: "this is a sample post")
+
+      Jobs::DetectTranslation.new.execute(post_id: post.id)
+
+      expect(post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).to eq("en")
+    end
+  end
+end


### PR DESCRIPTION
Each time a post is getting serialized, we check if the post's language has already been detected or not. If it has, there are no real side effects, and if it hasn't, the plugin sends a request to the enabled translator to detect the post's language.

The problem happens when we have small actions posts with no raw and the job keeps getting queued endlessly. I considered adding some checks at Jobs::DetectTranslation, or `cluster_concurrency 1`, so it doesn't re-trigger in the event some actions happen too quickly, but it might seem unnecessary. We'll see.

This PR prevents us from sending the post for language detection.

(There will be another PR to handle Amazon's errors due to misconfiguration)