### PR TITLE
FIX: Avoid publishing post when there is no change

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -21,6 +21,8 @@ en:
     not_supported: "This language is not supported by the translator."
     too_long: "This post is too long to be translated by the translator."
     not_available: "The translator service is currently not available."
+    amazon:
+      invalid_credentials: "The provided credentials for AWS translate are invalid."
 
     microsoft:
       missing_token: "The translator was unable to retrieve a valid token."

--- a/plugin.rb
+++ b/plugin.rb
@@ -144,8 +144,10 @@ after_initialize do
 
         DistributedMutex.synchronize("detect_translation_#{post.id}") do
           "DiscourseTranslator::#{SiteSetting.translator}".constantize.detect(post)
-          post.save_custom_fields unless post.custom_fields_clean?
-          post.publish_change_to_clients! :revised
+          if !post.custom_fields_clean?
+            post.save_custom_fields
+            post.publish_change_to_clients! :revised
+          end
         end
       end
     end

--- a/services/discourse_translator/amazon.rb
+++ b/services/discourse_translator/amazon.rb
@@ -105,16 +105,20 @@ module DiscourseTranslator
 
       return if text.blank?
 
-      detected_lang =
-        client.translate_text(
-          {
-            text: text,
-            source_language_code: "auto",
-            target_language_code: SUPPORTED_LANG_MAPPING[I18n.locale],
-          },
-        )&.source_language_code
+      begin
+        detected_lang =
+          client.translate_text(
+            {
+              text: text,
+              source_language_code: "auto",
+              target_language_code: SUPPORTED_LANG_MAPPING[I18n.locale],
+            },
+          )&.source_language_code
 
-      assign_lang_custom_field(topic_or_post, detected_lang)
+        assign_lang_custom_field(topic_or_post, detected_lang)
+      rescue Aws::Errors::MissingCredentialsError
+        raise I18n.t("translator.amazon.invalid_credentials")
+      end
     end
 
     def self.translate(topic_or_post)


### PR DESCRIPTION
In the `Job::DetectTranslation`, sometimes missing "detection" can lead to the post getting published again despite there being no changes. This then causes the post to re-serialize, and enqueue `Job::DetectTranslation` again. 🔥 

This PR ensures that post publishing only happens if there was a change in the custom fields.