### PR TITLE
DEV: Skip processing small actions

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -140,7 +140,7 @@ after_initialize do
         return if !SiteSetting.translator_enabled
 
         post = Post.find_by(id: args[:post_id])
-        return unless post
+        return if post.nil? || post.raw.blank? || post.post_type == Post.types[:small_action]
 
         DistributedMutex.synchronize("detect_translation_#{post.id}") do
           "DiscourseTranslator::#{SiteSetting.translator}".constantize.detect(post)
@@ -155,6 +155,8 @@ after_initialize do
 
   def post_process(post)
     return if !SiteSetting.translator_enabled
+    return if post.raw.blank? || post.post_type == Post.types[:small_action]
+
     Jobs.enqueue(:detect_translation, post_id: post.id)
   end
   listen_for :post_process

--- a/spec/jobs/detect_translation_spec.rb
+++ b/spec/jobs/detect_translation_spec.rb
@@ -22,6 +22,15 @@ describe Jobs::DetectTranslation do
     expect(post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).to be_nil
   end
 
+  it "does not detect translation for small posts" do
+    SiteSetting.translator_enabled = false
+
+    post = Fabricate(:small_action)
+    Jobs::DetectTranslation.new.execute(post_id: post.id)
+
+    expect(post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).to be_nil
+  end
+
   describe "translator enabled" do
     before { SiteSetting.translator_enabled = true }
 


### PR DESCRIPTION
This is an extension of this commit - https://github.com/discourse/discourse-translator/commit/1c84ffeab33764de75931b66398e6889e87cabd7

We had a problem on a site where a bunch of jobs were enqueued to detect the language of the same small post. Not sure what triggered this, but it caused an endless stream of `revised` message bus messages to the client, causing network requests to flood the server and rate limit clients.

This does a super-safe job of 
1. not enqueueing the process job for small/empty posts
2. returning early in the job if a post somehow made it through