### PR TITLE
FIX: Don't error out on deleted users

### DIFF
--- a/lib/discourse_translator/guardian_extension.rb
+++ b/lib/discourse_translator/guardian_extension.rb
@@ -8,6 +8,7 @@ module DiscourseTranslator::GuardianExtension
   def poster_group_allow_translate?(post)
     return false if !current_user
     return true if SiteSetting.restrict_translation_by_poster_group_map.empty?
+    return false if post.user.nil?
     post.user.in_any_groups?(SiteSetting.restrict_translation_by_poster_group_map)
   end
 end

--- a/spec/lib/guardian_extension_spec.rb
+++ b/spec/lib/guardian_extension_spec.rb
@@ -25,6 +25,24 @@ describe DiscourseTranslator::GuardianExtension do
     end
   end
 
+  describe "deleted poster" do
+    fab!(:group)
+    fab!(:user)
+    fab!(:poster) { Fabricate(:user, groups: [group]) }
+    fab!(:post) { Fabricate(:post, user: poster) }
+    let!(:guardian) { Guardian.new(user) }
+
+    describe "#poster_group_allow_translate?" do
+      it "returns false when the post user has been deleted" do
+        SiteSetting.restrict_translation_by_poster_group = "#{group.id}"
+
+        post.update(user: nil)
+
+        expect(guardian.poster_group_allow_translate?(post)).to eq(false)
+      end
+    end
+  end
+
   describe "logged in user" do
     fab!(:group)
     fab!(:user) { Fabricate(:user, groups: [group]) }
@@ -45,7 +63,7 @@ describe DiscourseTranslator::GuardianExtension do
       end
     end
 
-    describe "#poster_group_allow_translate??" do
+    describe "#poster_group_allow_translate?" do
       it "returns true when the post user is in restrict_translation_by_poster_group" do
         SiteSetting.restrict_translation_by_poster_group = "#{group.id}"
 


### PR DESCRIPTION
### What is the problem?

The `GuardianExtension#poster_group_allow_translate?` method restricts and determines whether a post can be translated based on the poster's group membership. There are reports that this errors out when deleting spammers.

The problem is that when a spammer is deleted, their post `user_id` is nullified, and because the above method doesn't account for this case, we try to call `#in_any_groups?` on `nil`, which errors out.

This PR fixes that by explicitly accounting for the case of a post with a `nil` user ID.

---

We have to make a decision here, since we're losing the history of which groups the poster was in, whether the post should be translatable or not. I'm defaulting to `false` here. It should be a minor thing as deleting a spam user should hide or delete their post as well.