### PR TITLE
Send referer header to google.

### DIFF
--- a/services/discourse_translator/google.rb
+++ b/services/discourse_translator/google.rb
@@ -121,7 +121,7 @@ module DiscourseTranslator
           body: URI.encode_www_form(body),
           headers: {
             "Content-Type" => "application/x-www-form-urlencoded",
-            "Referer" => Discourse.base_url
+            "Referer" => Discourse.base_url,
           },
         )
 

--- a/services/discourse_translator/google.rb
+++ b/services/discourse_translator/google.rb
@@ -121,6 +121,7 @@ module DiscourseTranslator
           body: URI.encode_www_form(body),
           headers: {
             "Content-Type" => "application/x-www-form-urlencoded",
+            "Referer" => Discourse.base_url
           },
         )
 


### PR DESCRIPTION
No globe appears on non-English posts on my forum and the error in production.log is ```Job exception: Requests from referer <empty> are blocked.```

The working fix is from /u/arkshine on the forum, see https://meta.discourse.org/t/why-is-there-no-earth-icon-after-i-configured-the-google-translator-api/280405

