### PR TITLE
DEV: fix spec for mocha 2.4.1

### DIFF
--- a/spec/services/google_spec.rb
+++ b/spec/services/google_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe DiscourseTranslator::Google do
           body: URI.encode_www_form(body),
           headers: {
             "Content-Type" => "application/x-www-form-urlencoded",
+            "Referer" => "http://test.localhost",
           },
         )
         .returns(


### PR DESCRIPTION
I suspect the spec was passing before due to a regression in mocha which has been fixed: https://github.com/freerange/mocha/commit/3b60b7df390bce19b928099281c9af8bccbe8472

Not 100% sure, but the criticality of the fix in a spec doesn’t seem to necessitate more investigation.