### PR TITLE
FEATURE: Add Azure key ProblemChecker

### DIFF
--- a/app/services/problem_check/microsoft_azure_key.rb
+++ b/app/services/problem_check/microsoft_azure_key.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ProblemCheck::MicrosoftAzureKey < ProblemCheck
+  self.priority = "high"
+
+  def call
+    return no_problem unless SiteSetting.translator_enabled
+    return no_problem if SiteSetting.translator != "Microsoft"
+    return problem if SiteSetting.translator_azure_subscription_key.blank?
+
+    no_problem
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -30,3 +30,6 @@ en:
   not_in_group:
     user_not_in_group: "You don't belong to a group allowed to translate."
     poster_not_in_group: "Post wasn't made by an user in an allowed group."
+  dashboard:
+    problem:
+      microsoft_azure_key: "Microsoft was used as the translator, but no Azure Subscription Key was provided."

--- a/plugin.rb
+++ b/plugin.rb
@@ -35,6 +35,9 @@ after_initialize do
     end
   end
 
+  require_relative "app/services/problem_check/microsoft_azure_key"
+  register_problem_check ProblemCheck::MicrosoftAzureKey
+
   class DiscourseTranslator::TranslatorController < ::ApplicationController
     before_action :ensure_logged_in
 

--- a/spec/services/problem_check/microsoft_azure_key_spec.rb
+++ b/spec/services/problem_check/microsoft_azure_key_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe ProblemCheck::MicrosoftAzureKey do
+  subject(:check) { described_class.new }
+
+  describe ".call" do
+    before { SiteSetting.stubs(translator_enabled: enabled) }
+
+    context "when plugin is disabled" do
+      let(:enabled) { false }
+
+      it { expect(check).to be_chill_about_it }
+    end
+
+    context "when plugin is enabled" do
+      let(:enabled) { true }
+
+      it "when translator is not Micorsoft" do
+        SiteSetting.translator = "Google"
+
+        expect(check).to be_chill_about_it
+      end
+
+      context "when translator is microsoft" do
+        it "when Azure key is not provided" do
+          SiteSetting.translator_azure_subscription_key = ""
+
+          expect(check).to have_a_problem.with_priority("high").with_message(
+            I18n.t("dashboard.problem.microsoft_azure_key"),
+          )
+        end
+
+        it "when Azure key is provided" do
+          SiteSetting.translator_azure_subscription_key = "foo"
+
+          expect(check).to be_chill_about_it
+        end
+      end
+    end
+  end
+end

--- a/spec/services/problem_check/microsoft_azure_key_spec.rb
+++ b/spec/services/problem_check/microsoft_azure_key_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ProblemCheck::MicrosoftAzureKey do
     context "when plugin is enabled" do
       let(:enabled) { true }
 
-      it "when translator is not Micorsoft" do
+      it "when translator is not Microsoft" do
         SiteSetting.translator = "Google"
 
         expect(check).to be_chill_about_it


### PR DESCRIPTION
Added a Problem checker with a "high" priority for the Azure key, so sit administrators can see the problem of missing Azure key on the dashboard in real time when the translator is configured as Microsoft.

## Screenshot

![image](https://github.com/user-attachments/assets/8d4bfa1b-8062-4394-9cd2-d28495b7666f)
