### PR TITLE
DEV: Do not log Job Exception: No Azure Key

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -120,10 +120,14 @@ after_initialize do
         return unless post
 
         DistributedMutex.synchronize("detect_translation_#{post.id}") do
-          "DiscourseTranslator::#{SiteSetting.translator}".constantize.detect(post)
-          if !post.custom_fields_clean?
-            post.save_custom_fields
-            post.publish_change_to_clients! :revised
+          begin
+            "DiscourseTranslator::#{SiteSetting.translator}".constantize.detect(post)
+            if !post.custom_fields_clean?
+              post.save_custom_fields
+              post.publish_change_to_clients! :revised
+            end
+          rescue ::DiscourseTranslator::MicrosoftNoAzureKeyError
+            # We already have ProblemCheck::MicrosoftAzureKey, no need to log errors here
           end
         end
       end

--- a/services/discourse_translator/microsoft.rb
+++ b/services/discourse_translator/microsoft.rb
@@ -3,6 +3,9 @@
 require_relative "base"
 
 module DiscourseTranslator
+  class MicrosoftNoAzureKeyError < TranslatorError
+  end
+
   class Microsoft < Base
     TRANSLATE_URI = "https://api.cognitive.microsofttranslator.com/translate"
     DETECT_URI = "https://api.cognitive.microsofttranslator.com/detect"
@@ -184,7 +187,7 @@ module DiscourseTranslator
 
     def self.default_headers
       if SiteSetting.translator_azure_subscription_key.blank?
-        raise TranslatorError.new(I18n.t("translator.microsoft.missing_key"))
+        raise MicrosoftNoAzureKeyError.new(I18n.t("translator.microsoft.missing_key"))
       end
 
       headers = {


### PR DESCRIPTION
In the previous commit (95e2043) we used ProblemCheck to alert the administrator of the problem of missing Microsoft Azure Key. Therefore, it is no longer necessary to log the error about missing Azure Key. This commit adds a rescue for this error to remove it from the log.