### PR TITLE
FEATURE: Add translator error ProblemCheck for Microsoft 

### DIFF
--- a/app/services/problem_check/translator_error.rb
+++ b/app/services/problem_check/translator_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ProblemCheck::TranslatorError < ProblemCheck::InlineProblemCheck
+  self.priority = "high"
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -33,3 +33,4 @@ en:
   dashboard:
     problem:
       microsoft_azure_key: "Microsoft was used as the translator, but no Azure Subscription Key was provided."
+      translator_error: "%{provider} reported a translation error with code %{code}: %{message}"

--- a/plugin.rb
+++ b/plugin.rb
@@ -36,7 +36,9 @@ after_initialize do
   end
 
   require_relative "app/services/problem_check/microsoft_azure_key"
+  require_relative "app/services/problem_check/translator_error"
   register_problem_check ProblemCheck::MicrosoftAzureKey
+  register_problem_check ProblemCheck::TranslatorError
 
   class DiscourseTranslator::TranslatorController < ::ApplicationController
     before_action :ensure_logged_in
@@ -126,8 +128,8 @@ after_initialize do
               post.save_custom_fields
               post.publish_change_to_clients! :revised
             end
-          rescue ::DiscourseTranslator::MicrosoftNoAzureKeyError
-            # We already have ProblemCheck::MicrosoftAzureKey, no need to log errors here
+          rescue ::DiscourseTranslator::ProblemCheckedTranslationError
+            # The error was handled by ProblemCheck., no need to log errors here
           end
         end
       end

--- a/services/discourse_translator/base.rb
+++ b/services/discourse_translator/base.rb
@@ -6,6 +6,9 @@ module DiscourseTranslator
   class TranslatorError < ::StandardError
   end
 
+  class ProblemCheckedTranslationError < TranslatorError
+  end
+
   class Base
     def self.key_prefix
       "#{PLUGIN_NAME}:".freeze

--- a/services/discourse_translator/microsoft.rb
+++ b/services/discourse_translator/microsoft.rb
@@ -3,9 +3,6 @@
 require_relative "base"
 
 module DiscourseTranslator
-  class MicrosoftNoAzureKeyError < ProblemCheckedTranslationError
-  end
-
   class Microsoft < Base
     TRANSLATE_URI = "https://api.cognitive.microsofttranslator.com/translate"
     DETECT_URI = "https://api.cognitive.microsofttranslator.com/detect"
@@ -180,11 +177,13 @@ module DiscourseTranslator
 
       if response.status != 200
         if response_body["error"] && response_body["error"]["code"]
-          ProblemCheckTracker[:translator_error].problem!(details: {
-            provider: "Microsoft",
-            code: response_body["error"]["code"],
-            message: response_body["error"]["message"]
-          })
+          ProblemCheckTracker[:translator_error].problem!(
+            details: {
+              provider: "Microsoft",
+              code: response_body["error"]["code"],
+              message: response_body["error"]["message"],
+            },
+          )
           raise ProblemCheckedTranslationError.new(response_body)
         end
         raise TranslatorError.new(response_body)
@@ -196,7 +195,7 @@ module DiscourseTranslator
 
     def self.default_headers
       if SiteSetting.translator_azure_subscription_key.blank?
-        raise MicrosoftNoAzureKeyError.new(I18n.t("translator.microsoft.missing_key"))
+        raise ProblemCheckedTranslationError.new(I18n.t("translator.microsoft.missing_key"))
       end
 
       headers = {


### PR DESCRIPTION
What does it add?
=================

This commit brings error messages from Microsoft Translator to the
administrator dashboard.

Specifically, a new InlineProblemCheck has been added, which reports the
error information in a human-readable way on the administrator dashboard
every time the translator server reports an error. When the translation
is successful, the error is considered to have been fixed and removed
from the dashboard.

ref: /t/134047

Screenshot
=========

![image](https://github.com/user-attachments/assets/8e0bbc5b-d1eb-4a06-8c0c-506f89c54afc)
