### PR TITLE
FIX: always use body of post to detect language

### DIFF
--- a/services/discourse_translator/google.rb
+++ b/services/discourse_translator/google.rb
@@ -75,9 +75,13 @@ module DiscourseTranslator
     end
 
     def self.detect(topic_or_post)
+      text =
+        topic_or_post.class.name == "Post" ? topic_or_post.cooked
+          : topic_or_post.first_post&.cooked
+
       topic_or_post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] ||= result(
         DETECT_URI,
-        q: get_text(topic_or_post).truncate(MAXLENGTH, omission: nil),
+        q: text.truncate(MAXLENGTH, omission: nil),
       )[
         "detections"
       ][
@@ -86,6 +90,7 @@ module DiscourseTranslator
         "language"
       ]
     end
+
 
     def self.translate_supported?(source, target)
       res = result(SUPPORT_URI, target: SUPPORTED_LANG_MAPPING[target])

--- a/services/discourse_translator/google.rb
+++ b/services/discourse_translator/google.rb
@@ -76,8 +76,7 @@ module DiscourseTranslator
 
     def self.detect(topic_or_post)
       text =
-        topic_or_post.class.name == "Post" ? topic_or_post.cooked
-          : topic_or_post.first_post&.cooked
+        topic_or_post.class.name == "Post" ? topic_or_post.cooked : topic_or_post.first_post&.cooked
 
       topic_or_post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] ||= result(
         DETECT_URI,
@@ -90,7 +89,6 @@ module DiscourseTranslator
         "language"
       ]
     end
-
 
     def self.translate_supported?(source, target)
       res = result(SUPPORT_URI, target: SUPPORTED_LANG_MAPPING[target])


### PR DESCRIPTION
fixes a bug where posts with foreign-language first-post bodies and user-language topic title would error out with a message like "Bad language pair: en|en"

this was because the plugin was only sending the topic title to the google translate /detect endpoint, getting 'en' and then passing 'en' as both source and target to google, which hadles that with an error code return.

solution here is: for first-post translations, use the body of the post to detect the language, as we do with subsequent posts