### PR TITLE
Handle same language translations

### DIFF
--- a/services/discourse_translator/google.rb
+++ b/services/discourse_translator/google.rb
@@ -104,9 +104,7 @@ module DiscourseTranslator
       # string.
       # ---
       # here we handle that situation by returning the original string if the source and target lang are the same.
-      if (detected_lang&.to_s.eql? I18n.locale.to_s)
-        return [detected_lang,get_text(topic_or_post)]
-      end
+      return detected_lang, get_text(topic_or_post) if (detected_lang&.to_s.eql? I18n.locale.to_s)
 
       raise I18n.t("translator.failed") unless translate_supported?(detected_lang, I18n.locale)
 

--- a/services/discourse_translator/google.rb
+++ b/services/discourse_translator/google.rb
@@ -96,6 +96,18 @@ module DiscourseTranslator
     def self.translate(topic_or_post)
       detected_lang = detect(topic_or_post)
 
+      # the translate button appears if a given post is in a foreign language.
+      # however the title of the topic may be in a different language, and may be in the user's language.
+      # if this is the case, when this is called for a topic, the detected_lang will be the user's language,
+      # so the user's language and the detected language will be the same. For example, both could be "en"
+      # google will choke on this and return an error instead of gracefully handling it by returning the original
+      # string.
+      # ---
+      # here we handle that situation by returning the original string if the source and target lang are the same.
+      if (detected_lang&.to_s.eql? I18n.locale.to_s)
+        return [detected_lang,get_text(topic_or_post)]
+      end
+
       raise I18n.t("translator.failed") unless translate_supported?(detected_lang, I18n.locale)
 
       translated_text =

--- a/spec/services/google_spec.rb
+++ b/spec/services/google_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe DiscourseTranslator::Google do
 
       2.times do
         expect(post.custom_fields[::DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).to eq(
-                                                                                           detected_lang,
-                                                                                         )
+          detected_lang,
+        )
       end
     end
 
     it "should truncate string to 5000 characters" do
       length = 6000
-      post.cooked = rand(36 ** length).to_s(36)
+      post.cooked = rand(36**length).to_s(36)
       detected_lang = "en"
 
       request_url = "#{DiscourseTranslator::Google::DETECT_URI}"

--- a/spec/services/google_spec.rb
+++ b/spec/services/google_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe DiscourseTranslator::Google do
 
       2.times do
         expect(post.custom_fields[::DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).to eq(
-          detected_lang,
-        )
+                                                                                           detected_lang,
+                                                                                         )
       end
     end
 
     it "should truncate string to 5000 characters" do
       length = 6000
-      post.cooked = rand(36**length).to_s(36)
+      post.cooked = rand(36 ** length).to_s(36)
       detected_lang = "en"
 
       request_url = "#{DiscourseTranslator::Google::DETECT_URI}"
@@ -74,6 +74,7 @@ RSpec.describe DiscourseTranslator::Google do
   end
 
   describe ".translate_supported?" do
+    let(:topic) { Fabricate(:topic, title: "This title is in english") }
     it "should equate source language to target" do
       source = "en"
       target = "fr"
@@ -82,6 +83,12 @@ RSpec.describe DiscourseTranslator::Google do
       )
       expect(described_class.translate_supported?(source, target)).to be true
     end
+
+    it "should pass through strings already in target language" do
+      lang = I18n.locale
+      described_class.expects(:detect).returns(lang)
+      expect(described_class.translate(topic)).to eq([lang, "This title is in english"])
+    end
   end
 
   describe ".translate" do
@@ -89,7 +96,7 @@ RSpec.describe DiscourseTranslator::Google do
 
     it "raises an error on failure" do
       described_class.expects(:access_token).returns("12345")
-      described_class.expects(:detect).returns("en")
+      described_class.expects(:detect).returns("__")
 
       Excon.expects(:post).returns(
         mock_response.new(
@@ -106,7 +113,7 @@ RSpec.describe DiscourseTranslator::Google do
 
     it "raises an error when the response is not JSON" do
       described_class.expects(:access_token).returns("12345")
-      described_class.expects(:detect).returns("en")
+      described_class.expects(:detect).returns("__")
 
       Excon.expects(:post).returns(mock_response.new(413, "<html><body>some html</body></html>"))
 


### PR DESCRIPTION
see comment for rationale here - but google chokes on en=>en translations and they are an inevitable effect of how our UI presents the translate feature. this happens any time a topic title is in the same language as the user's.

this fixes that by updating the google service to pass through same-language translation requests.