### PR TITLE
PERF: Move per-post language detection job into batches using redis

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -174,8 +174,6 @@ after_initialize do
     end
   end
 
-  on(:post_process) { |post| Jobs.enqueue(:detect_translation, post_id: post.id) }
-
   topic_view_post_custom_fields_allowlister { [::DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] }
 
   require_relative "lib/discourse_translator/guardian_extension"

--- a/spec/jobs/detect_posts_translation_spec.rb
+++ b/spec/jobs/detect_posts_translation_spec.rb
@@ -4,6 +4,7 @@ require "aws-sdk-translate"
 
 describe Jobs::DetectPostsTranslation do
   fab!(:posts) { Fabricate.times(5, :post) }
+  let(:redis_key) { DiscourseTranslator::LANG_DETECT_NEEDED }
 
   before do
     SiteSetting.translator_enabled = true
@@ -14,7 +15,7 @@ describe Jobs::DetectPostsTranslation do
       { translated_text: "大丈夫", source_language_code: "en", target_language_code: "jp" },
     )
     Aws::Translate::Client.stubs(:new).returns(client)
-    posts.each { |post| Discourse.redis.sadd?(DiscourseTranslator::LANG_DETECT_NEEDED, post.id) }
+    posts.each { |post| Discourse.redis.sadd?(redis_key, post.id) }
   end
 
   it "processes posts in batches and updates their translations" do
@@ -25,7 +26,7 @@ describe Jobs::DetectPostsTranslation do
       expect(post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).not_to be_nil
     end
 
-    expect(Discourse.redis.smembers(DiscourseTranslator::LANG_DETECT_NEEDED)).to be_empty
+    expect(Discourse.redis.smembers(redis_key)).to be_empty
   end
 
   it "does not process posts if the translator is disabled" do
@@ -37,48 +38,39 @@ describe Jobs::DetectPostsTranslation do
       expect(post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD]).to be_nil
     end
 
-    expect(Discourse.redis.smembers(DiscourseTranslator::LANG_DETECT_NEEDED)).to match_array(
-      posts.map(&:id).map(&:to_s),
-    )
+    expect(Discourse.redis.smembers(redis_key)).to match_array(posts.map(&:id).map(&:to_s))
   end
 
   it "processes a maximum of MAX_QUEUE_SIZE posts per run" do
     large_number = 2000
-    large_number.times { |i| Discourse.redis.sadd?(DiscourseTranslator::LANG_DETECT_NEEDED, i + 1) }
+    large_number.times { |i| Discourse.redis.sadd?(redis_key, i + 1) }
     described_class.new.execute({})
 
-    remaining = Discourse.redis.scard(DiscourseTranslator::LANG_DETECT_NEEDED)
+    remaining = Discourse.redis.scard(redis_key)
     expect(remaining).to eq(large_number - Jobs::DetectPostsTranslation::MAX_QUEUE_SIZE)
   end
 
   it "handles an empty Redis queue gracefully" do
-    Discourse.redis.del(DiscourseTranslator::LANG_DETECT_NEEDED)
+    Discourse.redis.del(redis_key)
     expect { described_class.new.execute({}) }.not_to raise_error
   end
 
   it "removes successfully processed posts from Redis" do
     described_class.new.execute({})
 
-    posts.each do |post|
-      expect(
-        Discourse.redis.sismember(DiscourseTranslator::LANG_DETECT_NEEDED, post.id),
-      ).to be_falsey
-    end
+    posts.each { |post| expect(Discourse.redis.sismember(redis_key, post.id)).to be_falsey }
   end
 
   it "skips posts that no longer exist" do
     non_existent_post_id = -1
-    Discourse.redis.sadd?(DiscourseTranslator::LANG_DETECT_NEEDED, non_existent_post_id)
+    Discourse.redis.sadd?(redis_key, non_existent_post_id)
 
     expect { described_class.new.execute({}) }.not_to raise_error
 
-    expect(
-      Discourse.redis.sismember(DiscourseTranslator::LANG_DETECT_NEEDED, non_existent_post_id),
-    ).to be_falsey
+    expect(Discourse.redis.sismember(redis_key, non_existent_post_id)).to be_falsey
   end
 
   it "ensures posts are processed within a distributed mutex" do
-    mutex_spy = instance_spy(DistributedMutex)
     allow(DistributedMutex).to receive(:synchronize).and_yield
 
     described_class.new.execute({})

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Post do
+  before { SiteSetting.translator_enabled = true }
+
   describe "translator custom fields" do
     let(:post) do
       Fabricate(
@@ -16,10 +18,6 @@ RSpec.describe Post do
         },
       )
     end
-
-    before { SiteSetting.translator_enabled = true }
-
-    after { SiteSetting.translator_enabled = false }
 
     it "should reset custom fields when post has been updated" do
       post.update!(raw: "this is an updated post")

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -81,11 +81,9 @@ RSpec.describe PostSerializer do
               post.custom_fields["detected_language"] = nil
               post.save_custom_fields
 
-              serializer.can_translate
-
-              expect(
-                Discourse.redis.sismember(DiscourseTranslator::LANG_DETECT_NEEDED, post.id),
-              ).to eq(true)
+              expect { serializer.can_translate }.to change {
+                Discourse.redis.sismember(DiscourseTranslator::LANG_DETECT_NEEDED, post.id)
+              }.from(false).to(true)
             end
           end
 


### PR DESCRIPTION
Currently, upon post serialization, we spawn a
new job to detect the language of the post. This
could potentially flood sidekiq on larger sites.

This PR uses redis to keep track of posts that
need language detection, then schedules them in
a 5-minute-ly job, with a maximum of 1000 posts
at a time.

Note for the reviewer: This plugin doesn't seem to be using autoloading as it should yet, but that will come in a separate PR.