### PR TITLE
DEV: Move logic for language support from post serializer into translators

### DIFF
--- a/app/services/discourse_translator/base.rb
+++ b/app/services/discourse_translator/base.rb
@@ -60,5 +60,12 @@ module DiscourseTranslator
         topic_or_post.title
       end
     end
+
+    def self.language_supported?(detected_lang)
+      raise NotImplementedError unless self.const_defined?(:SUPPORTED_LANG_MAPPING)
+      supported_lang = const_get(:SUPPORTED_LANG_MAPPING)
+      return false if supported_lang[I18n.locale].nil?
+      detected_lang != supported_lang[I18n.locale]
+    end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -50,10 +50,10 @@ after_initialize do
       Discourse.redis.sadd?(DiscourseTranslator::LANG_DETECT_NEEDED, object.id)
       false
     else
-      detected_lang !=
-        "DiscourseTranslator::#{SiteSetting.translator}::SUPPORTED_LANG_MAPPING".constantize[
-          I18n.locale
-        ]
+      detected_lang.to_sym != I18n.locale &&
+        "DiscourseTranslator::#{SiteSetting.translator}".constantize.language_supported?(
+          detected_lang,
+        )
     end
   end
 end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe PostSerializer do
 
           describe "when post has DETECTED_LANG_CUSTOM_FIELD matches user locale" do
             before do
-              post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "en"
+              I18n.stubs(:locale).returns(:xx)
+              post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] = "xx"
               post.save
             end
 

--- a/spec/services/base_spec.rb
+++ b/spec/services/base_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DiscourseTranslator::Base do
+  class TestTranslator < DiscourseTranslator::Base
+    SUPPORTED_LANG_MAPPING = { en: "en", ar: "ar", es_MX: "es-MX", pt: "pt" }
+  end
+
+  class EmptyTranslator < DiscourseTranslator::Base
+  end
+
+  describe ".language_supported?" do
+    it "raises an error when the method is not implemented" do
+      expect { EmptyTranslator.language_supported?("en") }.to raise_error(NotImplementedError)
+    end
+
+    it "returns false when the locale is not supported" do
+      I18n.stubs(:locale).returns(:xx)
+      expect(TestTranslator.language_supported?("en")).to eq(false)
+    end
+
+    it "returns true when the detected language is not the current locale" do
+      I18n.locale = :pt
+      expect(TestTranslator.language_supported?("en")).to eq(true)
+      expect(TestTranslator.language_supported?("ar")).to eq(true)
+      expect(TestTranslator.language_supported?("es-MX")).to eq(true)
+    end
+
+    it "returns false when the detected language is the detected locale" do
+      I18n.locale = :pt
+      expect(TestTranslator.language_supported?("pt")).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Currently, the `post.can_translate` attribute is determined in the post serializer itself, by checking if the `detected_language` of the post is translatable by the selected translator (e.g. Google, Microsoft)

`post.can_translate` determines if the translate globe is visible on a post.
<img width="634" alt="Screenshot 2024-11-22 at 1 20 49 AM" src="https://github.com/user-attachments/assets/0095a6c4-d94b-4dbe-8548-c83b9348976b">

This PR moves the check into the translator itself using the `language_supported?` method, and the translator can determine if a language is translatable rather than doing the check outside the translator. This is needed because Discourse AI does not have the limitation of translatable languages, and the return result of `language_supported?` will always be true, putting the check inside the post serializer has limitations since all translators will be required to define a SUPPORTED_LANG_MAPPING when there doesn't need to be one always.