### PR TITLE
FIX: Strips img tags (emojis) when detecting language

### DIFF
--- a/app/services/discourse_translator/base.rb
+++ b/app/services/discourse_translator/base.rb
@@ -61,6 +61,12 @@ module DiscourseTranslator
       end
     end
 
+    def self.strip_img_for_detection(detection_text)
+      html_doc = Nokogiri::HTML::DocumentFragment.parse(detection_text)
+      html_doc.css("img").remove
+      html_doc.to_html
+    end
+
     def self.language_supported?(detected_lang)
       raise NotImplementedError unless self.const_defined?(:SUPPORTED_LANG_MAPPING)
       supported_lang = const_get(:SUPPORTED_LANG_MAPPING)

--- a/app/services/discourse_translator/google.rb
+++ b/app/services/discourse_translator/google.rb
@@ -76,9 +76,11 @@ module DiscourseTranslator
     end
 
     def self.detect(topic_or_post)
+      detection_text = get_text(topic_or_post).truncate(MAXLENGTH, omission: nil)
+      detection_text = strip_img_for_detection(detection_text)
       topic_or_post.custom_fields[DiscourseTranslator::DETECTED_LANG_CUSTOM_FIELD] ||= result(
         DETECT_URI,
-        q: get_text(topic_or_post).truncate(MAXLENGTH, omission: nil),
+        q: detection_text,
       )[
         "detections"
       ][


### PR DESCRIPTION
Because in a text with many emojis, the detected language will unfortunately always be 'en'. Example text:

> Ein sehr schöner Beitrag über diesen Uhrturm und einem schönen Bild dazu 😍👍🙏🏻

This PR strips img tags before detecting language. The img tags will be present for translation.

### Additional context

In [Google Translate API](https://cloud.google.com/translate/troubleshooting), they actually do provide a way to skip certain tags but only when using the /translate endpoint, not the detect endpoint.

The method would be to add the `translate="no"` attribute to the respective html tags. This is also the same for [Microsoft Azure](https://learn.microsoft.com/en-us/azure/ai-services/translator/prevent-translation) and [Amazon](https://docs.aws.amazon.com/translate/latest/dg/customizing-translations-tags.html). But unfortunately this only works for /translate.