### PR TITLE
FIX: Also strip anchor tags when detecting language

### DIFF
--- a/app/services/discourse_translator/base.rb
+++ b/app/services/discourse_translator/base.rb
@@ -75,7 +75,7 @@ module DiscourseTranslator
     def self.strip_tags_for_detection(detection_text)
       html_doc = Nokogiri::HTML::DocumentFragment.parse(detection_text)
       html_doc.css("img").remove
-      html_doc.css("a").remove
+      html_doc.css("a.mention,a.lightbox").remove
       html_doc.to_html
     end
 

--- a/spec/services/base_spec.rb
+++ b/spec/services/base_spec.rb
@@ -41,9 +41,25 @@ describe DiscourseTranslator::Base do
       expect(DiscourseTranslator::Base.text_for_detection(post)).to eq("")
     end
 
-    it "strips anchor tags" do
-      post.cooked = "<a href='http://cat.com/image.png' />"
+    it "strips @ mention anchor tags" do
+      post.cooked = "<a class='mention' href='/u/cat' >cat</a>"
       expect(DiscourseTranslator::Base.text_for_detection(post)).to eq("")
+    end
+
+    it "strips lightbox anchor tags" do
+      post.cooked = "<a class='lightbox' href='http://cloudfront.net/image.png' />"
+      expect(DiscourseTranslator::Base.text_for_detection(post)).to eq("")
+    end
+
+    it "leaves other anchor tags alone" do
+      cooked = <<~HTML
+        <p>
+          <a href="http://cat.com/image.png"></a>
+          <a class="derp" href="http://cat.com/image.png"></a>
+        </p>
+        HTML
+      post.cooked = cooked
+      expect(DiscourseTranslator::Base.text_for_detection(post)).to eq(cooked)
     end
 
     it "truncates to DETECTION_CHAR_LIMIT of 1000" do


### PR DESCRIPTION
When @ mentioning a user, there is a chance that the username is detected as the language rather than the post content itself. Stripping the anchor tag will help with better language detection.

<img width="500" alt="Screenshot 2024-12-05 at 5 30 04 PM" src="https://github.com/user-attachments/assets/6ce3b755-760f-40e6-869e-88bfc9ce16fd">

<img width="500" alt="Screenshot 2024-12-05 at 5 30 20 PM" src="https://github.com/user-attachments/assets/c0ef431f-fce4-432e-811a-8261f6b83932">
