### PR TITLE
FIX: Skip images and quotes when sending for language detection

### DIFF
--- a/app/services/discourse_translator/base.rb
+++ b/app/services/discourse_translator/base.rb
@@ -74,8 +74,7 @@ module DiscourseTranslator
 
     def self.strip_tags_for_detection(detection_text)
       html_doc = Nokogiri::HTML::DocumentFragment.parse(detection_text)
-      html_doc.css("img").remove
-      html_doc.css("a.mention,a.lightbox").remove
+      html_doc.css("img", "aside.quote", "div.lightbox-wrapper", "a.mention,a.lightbox").remove
       html_doc.to_html
     end
 

--- a/spec/services/base_spec.rb
+++ b/spec/services/base_spec.rb
@@ -51,13 +51,23 @@ describe DiscourseTranslator::Base do
       expect(DiscourseTranslator::Base.text_for_detection(post)).to eq("")
     end
 
+    it "strips lightboxes" do
+      post.cooked = "<div class='lightbox-wrapper' />"
+      expect(DiscourseTranslator::Base.text_for_detection(post)).to eq("")
+    end
+
+    it "strips quotes" do
+      post.cooked = "<aside class='quote'>多言語トピック</aside>"
+      expect(DiscourseTranslator::Base.text_for_detection(post)).to eq("")
+    end
+
     it "leaves other anchor tags alone" do
       cooked = <<~HTML
         <p>
           <a href="http://cat.com/image.png"></a>
           <a class="derp" href="http://cat.com/image.png"></a>
         </p>
-        HTML
+      HTML
       post.cooked = cooked
       expect(DiscourseTranslator::Base.text_for_detection(post)).to eq(cooked)
     end


### PR DESCRIPTION
We're seeing some bugs where if a post starts with a image or quote, the translator provider thinks the post is english or the language of the quoted words.

This PR strips lightboxes and quotes when sending for language detection.