### PR TITLE
FIX: Strip detection text before truncation

### DIFF
--- a/app/services/discourse_translator/base.rb
+++ b/app/services/discourse_translator/base.rb
@@ -79,8 +79,9 @@ module DiscourseTranslator
     end
 
     def self.text_for_detection(topic_or_post)
-      strip_tags_for_detection(
-        get_text(topic_or_post).truncate(DETECTION_CHAR_LIMIT, omission: nil),
+      strip_tags_for_detection(get_text(topic_or_post)).truncate(
+        DETECTION_CHAR_LIMIT,
+        omission: nil,
       )
     end
 

--- a/spec/services/base_spec.rb
+++ b/spec/services/base_spec.rb
@@ -82,6 +82,11 @@ describe DiscourseTranslator::Base do
       post.cooked = text
       expect(DiscourseTranslator::Base.text_for_detection(post)).to eq(text)
     end
+
+    it "strips text before truncation" do
+      post.cooked = "<img src='http://example.com/image.png' />" + "a" * 1000
+      expect(DiscourseTranslator::Base.text_for_detection(post)).to eq("a" * 1000)
+    end
   end
 
   describe ".text_for_translation" do


### PR DESCRIPTION
Besides removing images, we also want to make sure that we truncate the text _after_ removing the image, otherwise text sent for detection would be empty.

e.g. a cooked post that looks like that

`<p></p><div class=\"lightbox-wrapper\"><a class=\"lightbox\" href=\"https://asd.cloudfront.net/original/4X/c/d/d/asd.jpeg\" data-download-href=\"/uploads/short-url/asd.jpeg?dl=1\" title=\"IMG_20928\"><img src=\"https://asd.asd.net/optimized/4X/c/d/d/asd.jpeg\" alt=\"IMG_2029\" data-base62-sha1=\"asd\" width=\"666\" height=\"500\" srcset=\"https://asd.cloudfront.net/optimized/4X/c/d/d/asd.jpeg, https://asd.cloudfront.net/optimized/4X/c/d/d/asd.jpeg 1.5x, https://asd.cloudfront.net/optimized/4X/c/d/d/asd.jpeg 2x\" data-dominant-color=\"767065\"><div class=\"meta\">\n<svg class=\"fa d-icon d-icon-far-image svg-icon\" aria-hidden=\"true\"><use href=\"#far-image\"></use></svg><span class=\"filename\">IMG_2029</span><span class=\"informations\">1920×1440 742 KB</span><svg class=\"fa d-icon d-icon-discourse-expand svg-icon\" aria-hidden=\"true\"><use href=\"#discourse-expand\"></use></svg>\n</div></a></div>\n<p>L’església romànica de Santa Margarida.</p>`

should strip the `div.lightbox` and send `<p>L’església romànica de Santa Margarida.</p>` but is sending `<p></p>` now due to the mis-order.