### PR TITLE
FEATURE: Experimental feature for viewing translated topics

### DIFF
--- a/assets/javascripts/discourse/components/show-original-content.gjs
+++ b/assets/javascripts/discourse/components/show-original-content.gjs
@@ -1,0 +1,46 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import concatClass from "discourse/helpers/concat-class";
+
+export default class ShowOriginalContent extends Component {
+  @service router;
+  @tracked isTranslated = true;
+
+  constructor() {
+    super(...arguments);
+    this.isTranslated = !new URLSearchParams(window.location.search).has(
+      "show"
+    );
+  }
+
+  @action
+  async showOriginal() {
+    const params = new URLSearchParams(window.location.search);
+    if (this.isTranslated) {
+      params.append("show", "original");
+    } else {
+      params.delete("show");
+    }
+    window.location.search = params.toString();
+  }
+
+  get title() {
+    return this.isTranslated
+      ? "translator.content_translated"
+      : "translator.content_not_translated";
+  }
+
+  <template>
+    <div class="discourse-translator_toggle-original">
+      <DButton
+        @icon="language"
+        @title={{this.title}}
+        class={{concatClass "btn btn-default" (if this.isTranslated "active")}}
+        @action={{this.showOriginal}}
+      />
+    </div>
+  </template>
+}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -2,3 +2,19 @@
   .fk-d-menu__inner-content {
   max-height: 50vh;
 }
+
+.topic-navigation.with-timeline .discourse-translator_toggle-original {
+  margin-bottom: 0.5em;
+}
+
+.topic-navigation.with-topic-progress
+  .discourse-translator_toggle-original
+  button {
+  height: 100%;
+}
+
+.discourse-translator_toggle-original {
+  button.active svg {
+    color: var(--tertiary);
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6,7 +6,7 @@ en:
           discourse_translator: "Discourse Translator"
   js:
     translator:
-      view_translation: "View translation"
-      hide_translation: "Hide translation"
+      content_not_translated: "Content not translated. Click to translate"
+      content_translated: "Content is translated. Click to view original"
       translated_from: "Translated from %{language} by %{translator}"
       translating: "Translating"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -20,6 +20,7 @@ en:
     experimental_anon_language_switcher: "Enable experimental language switcher for anonymous users. This will allow anonymous users to switch between translated versions of Discourse and user-contributed content in topics."
     errors:
       set_locale_cookie_requirements: "The experimental language switcher for anonymous users requires the `set locale from cookie` site setting to be enabled."
+    experimental_topic_translation: "Enable experimental topic translation feature. This replaces existing post in-line translation with a button that allows users to translate the entire topic."
   translator:
     failed: "The translator is unable to translate this content (%{source_locale}) to the default language of this site (%{target_locale})."
     not_supported: "This language is not supported by the translator."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -106,3 +106,6 @@ discourse_translator:
     default: false
     client: true
     validator: "LanguageSwitcherSettingValidator"
+  experimental_topic_translation:
+    default: false
+    client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -41,4 +41,18 @@ after_initialize do
   add_to_serializer :post, :can_translate do
     scope.can_translate?(object)
   end
+
+  add_to_serializer :post, :translated_cooked do
+    if !SiteSetting.experimental_topic_translation || scope.request.params["show"] == "original"
+      return nil
+    end
+    object.translation_for(I18n.locale) || nil
+  end
+
+  add_to_serializer :topic_view, :translated_title do
+    if !SiteSetting.experimental_topic_translation || scope.request.params["show"] == "original"
+      return nil
+    end
+    object.topic.translation_for(I18n.locale) || nil
+  end
 end

--- a/spec/system/full_page_translation_spec.rb
+++ b/spec/system/full_page_translation_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe "Full page translation", type: :system do
+  fab!(:japanese_user) { Fabricate(:user, locale: "ja") }
+  fab!(:site_local_user) { Fabricate(:user, locale: "en") }
+  fab!(:author) { Fabricate(:user) }
+
+  fab!(:topic) { Fabricate(:topic, title: "Life strategies from The Art of War", user: author) }
+  fab!(:post_1) do
+    Fabricate(:post, topic: topic, raw: "The masterpiece isn’t just about military strategy")
+  end
+  fab!(:post_2) do
+    Fabricate(:post, topic: topic, raw: "The greatest victory is that which requires no battle")
+  end
+
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+
+  before do
+    # topic translation setup
+    topic.set_detected_locale("en")
+    post_1.set_detected_locale("en")
+    post_2.set_detected_locale("en")
+
+    topic.set_translation("ja", "孫子兵法からの人生戦略")
+    topic.set_translation("es", "Estrategias de vida de El arte de la guerra")
+    post_1.set_translation("ja", "傑作は単なる軍事戦略についてではありません")
+    post_2.set_translation("ja", "最大の勝利は戦いを必要としないものです")
+  end
+
+  context "when the feature is enabled" do
+    before do
+      SiteSetting.translator_enabled = true
+      SiteSetting.allow_user_locale = true
+      SiteSetting.set_locale_from_cookie = true
+      SiteSetting.set_locale_from_param = true
+      SiteSetting.experimental_anon_language_switcher = true
+      SiteSetting.experimental_topic_translation = true
+    end
+
+    it "shows the correct language based on the selected language and login status" do
+      visit("/t/#{topic.slug}/#{topic.id}?lang=ja")
+      expect(topic_page.has_topic_title?("孫子兵法からの人生戦略")).to eq(true)
+      expect(find(topic_page.post_by_number_selector(1))).to have_content("傑作は単なる軍事戦略についてではありません")
+
+      visit("/t/#{topic.id}")
+      expect(topic_page.has_topic_title?("Life strategies from The Art of War")).to eq(true)
+      expect(find(topic_page.post_by_number_selector(1))).to have_content(
+        "The masterpiece isn’t just about military strategy",
+      )
+
+      sign_in(japanese_user)
+      visit("/")
+      visit("/t/#{topic.id}")
+      expect(topic_page.has_topic_title?("孫子兵法からの人生戦略")).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
This feature shows a fully translated topic in the user's language. For now, the topic needs to already have translations for the translated topic to show. If there are posts that have not been translated, the original content will be shown.

## Topic fully translated to site locale:
<img width="500" alt="Screenshot 2025-02-10 at 8 17 08 PM" src="https://github.com/user-attachments/assets/05d521c1-4591-4bb9-b10f-acb1ff5cbd64" />

## Topic fully translated to lang param:
<img width="500" alt="Screenshot 2025-02-10 at 8 17 27 PM" src="https://github.com/user-attachments/assets/cebe2bdf-515c-4d3f-b98a-1e457d201086" />

## Show original content of topic
<img width="500" alt="Screenshot 2025-02-10 at 8 21 06 PM" src="https://github.com/user-attachments/assets/300b6d5d-f535-4da3-a369-e4c69e2a016e" />

The `translated_title` is returned via the `TopicViewSerializer` and displayed via the `applyTransformations` API.
The `translated_cooked` is returned via the `PostSerializer` and displayed via `decorateCooked`.

This takes a different approach from the previous PR https://github.com/discourse/discourse-translator/pull/199 which overrode the `fancy_title` and `cooked` directly.