### PR TITLE
FIX: Set a stripped post's locale to site default locale

### DIFF
--- a/app/services/discourse_translator/base.rb
+++ b/app/services/discourse_translator/base.rb
@@ -88,7 +88,9 @@ module DiscourseTranslator
     end
 
     def self.save_detected_locale(translatable)
-      detected_locale = yield
+      # sometimes we may have a user post that is just an emoji
+      # in that case, we will just indicate the post is in the default locale
+      detected_locale = yield.presence || SiteSetting.default_locale
       translatable.set_detected_locale(detected_locale)
 
       detected_locale

--- a/spec/services/base_spec.rb
+++ b/spec/services/base_spec.rb
@@ -115,6 +115,14 @@ describe DiscourseTranslator::Base do
       expect(TestTranslator.detect(post)).to eq("en")
     end
 
+    it "saves the site default locale when detection is empty" do
+      SiteSetting.default_locale = "ja"
+
+      TestTranslator.save_detected_locale(post) { "" }
+
+      expect(post.detected_locale).to eq("ja")
+    end
+
     it "performs detection if no cached result" do
       TestTranslator.expects(:detect!).with(post).returns("es")
 


### PR DESCRIPTION
In posts where there is a just an image, the stripped text that is sent for locale detection can be ...

```
<p></p>
```

... as we do not send HTML for the image for locale detection. The stripped text would result in a `""` returned for detected locale, which would result in 

```
Detected locale can't be blank
```

This PR defaults the post to the site's locale. This is needed so that we do not keep sending the post to check the locale.