### PR TITLE
FIX: Do not translate bot posts

### DIFF
--- a/app/jobs/scheduled/automatic_translation_backfill.rb
+++ b/app/jobs/scheduled/automatic_translation_backfill.rb
@@ -46,6 +46,7 @@ module Jobs
         )
         AND m.deleted_at IS NULL
         AND m.#{content_column} != ''
+        AND m.user_id > 0
         ORDER BY m.id DESC
         LIMIT :limit
       SQL

--- a/plugin.rb
+++ b/plugin.rb
@@ -33,25 +33,25 @@ after_initialize do
   end
 
   on(:post_process_cooked) do |_, post|
-    if Guardian.new.can_detect_language?(post)
+    if Guardian.new.can_detect_language?(post) && post.user_id > 0
       Discourse.redis.sadd?(DiscourseTranslator::LANG_DETECT_NEEDED, post.id)
     end
   end
 
   on(:post_process_cooked) do |_, post|
-    if SiteSetting.automatic_translation_target_languages.present?
+    if SiteSetting.automatic_translation_target_languages.present? && post.user_id > 0
       Jobs.enqueue(:translate_translatable, type: "Post", translatable_id: post.id)
     end
   end
 
   on(:topic_created) do |topic|
-    if SiteSetting.automatic_translation_target_languages.present?
+    if SiteSetting.automatic_translation_target_languages.present? && topic.user_id > 0
       Jobs.enqueue(:translate_translatable, type: "Topic", translatable_id: topic.id)
     end
   end
 
   on(:topic_edited) do |topic|
-    if SiteSetting.automatic_translation_target_languages.present?
+    if SiteSetting.automatic_translation_target_languages.present? && topic.user_id > 0
       Jobs.enqueue(:translate_translatable, type: "Topic", translatable_id: topic.id)
     end
   end

--- a/spec/jobs/automatic_translation_backfill_spec.rb
+++ b/spec/jobs/automatic_translation_backfill_spec.rb
@@ -193,5 +193,13 @@ This is the scenario we are testing for:
       result = described_class.new.fetch_untranslated_model_ids(Post, "cooked", 50, %w[de es])
       expect(result).not_to include(post_1.id)
     end
+
+    it "does not return posts by bots" do
+      post_1.update(user: Discourse.system_user)
+
+      result = described_class.new.fetch_untranslated_model_ids(Post, "cooked", 50, %w[de es])
+
+      expect(result).not_to include(post_1.id)
+    end
   end
 end


### PR DESCRIPTION
Bot (e.g. Discobot) posts happen a lot during signups to users of various locales.

We do not want to translate these.