### PR TITLE
FIX: Add back i18n strings that were removed

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6,6 +6,8 @@ en:
           discourse_translator: "Discourse Translator"
   js:
     translator:
+      view_translation: "View translation"
+      hide_translation: "Hide translation"
       content_not_translated: "Content not translated. Click to translate"
       content_translated: "Content is translated. Click to view original"
       translated_from: "Translated from %{language} by %{translator}"


### PR DESCRIPTION
<img width="234" alt="Screenshot 2025-02-17 at 3 28 56 PM" src="https://github.com/user-attachments/assets/6e0a1e88-202d-4520-a95a-00a29b250e65" />

Adds this string back as it is still used.