### PR TITLE
FIX: Ensure old feature works with new and show translate button in correct scenarios

### DIFF
--- a/lib/discourse_translator/guardian_extension.rb
+++ b/lib/discourse_translator/guardian_extension.rb
@@ -23,10 +23,11 @@ module DiscourseTranslator::GuardianExtension
     return false if !user_group_allow_translate?
 
     if SiteSetting.experimental_topic_translation
-      return false if post.translation_for(I18n.locale).present?
       return false if post.locale_matches?(I18n.locale)
+      return false if post.translation_for(I18n.locale).present?
       true
     else
+      return false if post.locale_matches?(I18n.locale)
       poster_group_allow_translate?(post)
     end
   end

--- a/spec/lib/guardian_extension_spec.rb
+++ b/spec/lib/guardian_extension_spec.rb
@@ -166,7 +166,14 @@ describe DiscourseTranslator::GuardianExtension do
                 expect(guardian.can_translate?(post)).to eq(true)
               end
 
-              it "can translate when post does not have translation" do
+              it "cannot translate when post has translation for user locale" do
+                post.set_detected_locale("jp")
+                post.set_translation("pt", "Olá, mundo!")
+
+                expect(guardian.can_translate?(post)).to eq(false)
+              end
+
+              it "can translate when post does not have translation for user locale" do
                 post.set_detected_locale("jp")
 
                 expect(guardian.can_translate?(post)).to eq(true)
@@ -199,6 +206,18 @@ describe DiscourseTranslator::GuardianExtension do
 
             describe "locale is :pt" do
               before { I18n.stubs(:locale).returns(:pt) }
+
+              it "cannot translate when post detected locale matches i18n locale" do
+                post.set_detected_locale("pt")
+
+                expect(guardian.can_translate?(post)).to eq(false)
+              end
+
+              it "can translate when post's detected locale does not match i18n locale" do
+                post.set_detected_locale("jp")
+
+                expect(guardian.can_translate?(post)).to eq(true)
+              end
 
               it "cannot translate if poster is not in restrict_translation_by_poster_group" do
                 SiteSetting.restrict_translation_by_poster_group = "#{Group::AUTO_GROUPS[:staff]}"


### PR DESCRIPTION
In the older implementation of translation, there exists these two site settings are part of the criteria that determines if 🌐 shows up per post

* `restrict translation by group` - Only allowed groups can translate
* `restrict translation by poster group` - Only allow translation of posts made by users in allowed groups. If empty, allow translations of posts from all users.

In a recent update with experimental features, we updated the cases where 🌐 will show up and caused a regression where the 🌐 shows up for everyone in `restrict translation by group`, ignoring `restrict translation by poster group`.

This PR makes sure these two site settings are adhered to when the experimental topic setting is turned off.