### PR TITLE
UX: Show an obvious timeout error instead of a generic one

### DIFF
--- a/app/services/discourse_translator/base.rb
+++ b/app/services/discourse_translator/base.rb
@@ -78,7 +78,11 @@ module DiscourseTranslator
     end
 
     def self.save_translation(translatable, target_locale_sym = I18n.locale)
-      translation = yield
+      begin
+        translation = yield
+      rescue Timeout::Error
+        raise TranslatorError.new(I18n.t("translator.api_timeout"))
+      end
       translatable.set_translation(target_locale_sym, translation)
       translation
     end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -27,6 +27,7 @@ en:
     not_supported: "This language is not supported by the translator."
     too_long: "This post is too long to be translated by the translator."
     not_available: "The translator service is currently not available."
+    api_timeout: "The translator service took too long to respond. Please try again later."
     amazon:
       invalid_credentials: "The provided credentials for AWS translate are invalid."
 


### PR DESCRIPTION
There are times when using the DiscourseAi translator that we will face a Timeout::Error due to FinalDestination resolver. This will result in a generic error surfaced

<img width="300" alt="Screenshot 2025-02-18 at 12 49 36 AM" src="https://github.com/user-attachments/assets/71ae0c60-426d-4a27-bb86-7fcf98cd4512" />

This PR makes it obvious that the user can try again

<img width="500" alt="Screenshot 2025-02-18 at 12 50 20 AM" src="https://github.com/user-attachments/assets/58e0c7c1-647f-4cc5-9487-65a3d03b2c18" />
