### PR TITLE
FIX: Entry in .discourse-compatibility was wrong

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,4 +1,4 @@
-< 3.5.0.beta1-dev: 65d7ea2dbc9e7bf276e5ac3f9e23c2111e64e278
+< 3.5.0.beta1-dev: 7d411e458bdd449f8aead2bc07cedeb00b856798
 < 3.4.0.beta3-dev: b4cf3a065884816fa3f770248c2bf908ba65d8ac
 < 3.4.0.beta1-dev: 5346b4bafba2c2fb817f030a473b7bbca97b909c
 < 3.3.0.beta1-dev: 6750e10a6d9dfd3fc2c9a0cac5a83aca1a8ee401


### PR DESCRIPTION
https://github.com/discourse/discourse-translator/pull/210 set the commit hash to a commit from core, but it should have been set to a commit in discourse-translator before the breaking change was introduced. In this case, that's 7d411e458bdd449f8aead2bc07cedeb00b856798.