### PR TITLE
UX: Update copy indicating page is machine-translated

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8,7 +8,7 @@ en:
     translator:
       view_translation: "View translation"
       hide_translation: "Hide translation"
-      content_not_translated: "Content not translated. Click to translate"
-      content_translated: "Content is translated. Click to view original"
+      content_not_translated: "Page not translated. Click to translate"
+      content_translated: "Page is machine-translated. Click to view original"
       translated_from: "Translated from %{language} by %{translator}"
       translating: "Translating"


### PR DESCRIPTION
Update copy for experimental topic translation "Show Original" button.

<img width="288" alt="Screenshot 2025-02-18 at 10 41 44 PM" src="https://github.com/user-attachments/assets/735c340b-1018-4d30-8721-331b19d38f32" />
