### PR TITLE
FIX: Absent scope in serializer will cause reports to fail

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -62,7 +62,7 @@ after_initialize do
 
   register_modifier(:basic_post_serializer_cooked) do |cooked, serializer|
     if !SiteSetting.experimental_topic_translation ||
-         serializer.scope&.request&.params["show"] == "original" ||
+         serializer.scope&.request&.params&.[]("show") == "original" ||
          serializer.object.detected_locale == I18n.locale.to_s.gsub("_", "-")
       cooked
     else
@@ -72,7 +72,7 @@ after_initialize do
 
   register_modifier(:topic_serializer_fancy_title) do |fancy_title, serializer|
     if !SiteSetting.experimental_topic_translation ||
-         serializer.scope&.request&.params["show"] == "original" ||
+         serializer.scope&.request&.params&.[]("show") == "original" ||
          serializer.object.locale_matches?(I18n.locale)
       fancy_title
     else
@@ -82,7 +82,7 @@ after_initialize do
 
   register_modifier(:topic_view_serializer_fancy_title) do |fancy_title, serializer|
     if !SiteSetting.experimental_topic_translation ||
-         serializer.scope&.request&.params["show"] == "original" ||
+         serializer.scope&.request&.params&.[]("show") == "original" ||
          serializer.object.topic.locale_matches?(I18n.locale)
       fancy_title
     else


### PR DESCRIPTION
There is a little bug now due to data-explorer. Below is the stack trace:
```
plugins/discourse-translator/plugin.rb:75:in `block (2 levels) in activate!'
lib/discourse_plugin_registry.rb:293:in `apply_modifier'
app/serializers/basic_topic_serializer.rb:9:in `fancy_title'
active_model_serializers (0.8.4) lib/action_controller/serialization.rb:50:in `block (2 levels) in <module:Serialization>'
...
plugins/discourse-data-explorer/app/controllers/discourse_data_explorer/query_controller.rb:191:in `block (2 levels) in run'
```

This PR makes us be a bit more resilient when there is no scope present in the serializer.