### PR TITLE
FIX: Do not let 🌐 show up when the post is by a bot

### DIFF
--- a/lib/discourse_translator/guardian_extension.rb
+++ b/lib/discourse_translator/guardian_extension.rb
@@ -20,6 +20,7 @@ module DiscourseTranslator::GuardianExtension
   end
 
   def can_translate?(post)
+    return false if post.user.bot?
     return false if !user_group_allow_translate?
     return false if post.locale_matches?(I18n.locale)
 

--- a/spec/lib/guardian_extension_spec.rb
+++ b/spec/lib/guardian_extension_spec.rb
@@ -133,6 +133,11 @@ describe DiscourseTranslator::GuardianExtension do
         I18n.locale = :pt
       end
 
+      it "cannot translate bot posts" do
+        post.update!(user: Discourse.system_user)
+        expect(Guardian.new.can_translate?(post)).to eq(false)
+      end
+
       describe "anon user" do
         before { SiteSetting.restrict_translation_by_group = "#{Group::AUTO_GROUPS[:everyone]}" }
 


### PR DESCRIPTION
<img width="781" alt="Screenshot 2025-02-27 at 11 03 27 AM" src="https://github.com/user-attachments/assets/84c9c6bd-19cb-4094-aa73-de0bc582c701" />

We shouldn't be able to click 🌐  here since it is a bot post.