### PR TITLE
UX: Remove flash of  🌐 when the post has yet to have its locale determined

### DIFF
--- a/lib/discourse_translator/dual_text_translation.rb
+++ b/lib/discourse_translator/dual_text_translation.rb
@@ -15,7 +15,8 @@ module DiscourseTranslator
       end
 
       plugin.on(:topic_created) do |topic|
-        if SiteSetting.automatic_translation_target_languages.blank? && topic.user_id > 0
+        if SiteSetting.automatic_translation_target_languages.blank? &&
+             Guardian.new.can_detect_language?(topic.first_post) && topic.user_id > 0
           Jobs.enqueue(:detect_translatable_language, type: "Topic", translatable_id: topic.id)
         end
       end

--- a/lib/discourse_translator/guardian_extension.rb
+++ b/lib/discourse_translator/guardian_extension.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module DiscourseTranslator::GuardianExtension
+  POST_DETECTION_BUFFER = 10.seconds
+
   def user_group_allow_translate?
     return false if !current_user
     current_user.in_any_groups?(SiteSetting.restrict_translation_by_group_map)
@@ -22,6 +24,10 @@ module DiscourseTranslator::GuardianExtension
   def can_translate?(post)
     return false if !user_group_allow_translate?
     return false if post.locale_matches?(I18n.locale)
+
+    # we want to return false if the post is created within a short buffer ago,
+    # this prevents the 🌐from appearing and then disappearing if the lang is same as user's lang
+    return false if post.created_at > POST_DETECTION_BUFFER.ago && post.detected_locale.blank?
 
     if SiteSetting.experimental_topic_translation
       post.translation_for(I18n.locale).nil?


### PR DESCRIPTION
Bug:

https://github.com/user-attachments/assets/ca2c1fde-7694-416b-b41f-f519004af812

In the recording above, when a post is just created, we see the 🌐 appear for a brief moment, then disappear.

We typically want to show the 🌐 in case the post is not in the same language as the reader's. This works really well for old posts that do not have translation information. But since now all posts will be sent for locale detection on-create, it is a matter of seconds that the post's locale is determined. 

This PR adds a buffer of 10 seconds that will prevent the 🌐 from appearing if 1. it was just created _and_ 2. it doesn't have the locale yet.