### PR TITLE
DEV: Backfill translations for recently updated topics and posts first

### DIFF
--- a/app/jobs/scheduled/automatic_translation_backfill.rb
+++ b/app/jobs/scheduled/automatic_translation_backfill.rb
@@ -47,7 +47,7 @@ module Jobs
         AND m.deleted_at IS NULL
         AND m.#{content_column} != ''
         AND m.user_id > 0
-        ORDER BY m.id DESC
+        ORDER BY m.updated_at DESC
         LIMIT :limit
       SQL
     end

--- a/spec/jobs/automatic_translation_backfill_spec.rb
+++ b/spec/jobs/automatic_translation_backfill_spec.rb
@@ -176,9 +176,17 @@ This is the scenario we are testing for:
       post_7.set_translation("ja", "こんにちは")
     end
 
-    it "returns correct post ids needing translation in descending id" do
+    it "returns correct post ids needing translation in descending updated_at" do
+      # based on the table above, we will return post_7, post_6, post_3, post_2, post_1
+      # but we will jumble its updated_at to test if it is sorted correctly
+      post_6.update!(updated_at: 1.day.ago)
+      post_3.update!(updated_at: 2.days.ago)
+      post_2.update!(updated_at: 3.days.ago)
+      post_1.update!(updated_at: 4.days.ago)
+      post_7.update!(updated_at: 5.days.ago)
+
       result = described_class.new.fetch_untranslated_model_ids(Post, "cooked", 50, %w[de es])
-      expect(result).to include(post_7.id, post_6.id, post_3.id, post_2.id, post_1.id)
+      expect(result).to include(post_6.id, post_3.id, post_2.id, post_1.id, post_7.id)
     end
 
     it "does not return posts that are deleted" do


### PR DESCRIPTION
We currently backfill translations based on the most recently created posts and topics.

This results in some gap where older topics with new posts do not have a translated topic title

![image](https://github.com/user-attachments/assets/ed066984-e7bc-4d7e-afe7-82f3138e4299)

This PR just updates backfill by sorting using updated_at to fill the gaps. (a topic's updated_at is modified when there is a new post)