### PR TITLE
DEV: Plugin-wide verbose logging

### DIFF
--- a/app/jobs/scheduled/automatic_translation_backfill.rb
+++ b/app/jobs/scheduled/automatic_translation_backfill.rb
@@ -103,6 +103,11 @@ module Jobs
       topic_ids = fetch_untranslated_model_ids(Topic, "title", translations_per_model)
       translations_per_model = translations_per_run - topic_ids.size
       post_ids = fetch_untranslated_model_ids(Post, "cooked", translations_per_model)
+
+      DiscourseTranslator::VerboseLogger.log(
+        "Translating #{topic_ids.size} topics and #{post_ids.size} posts to #{backfill_locales.join(", ")}",
+      )
+
       return if topic_ids.empty? && post_ids.empty?
 
       translate_records(Topic, topic_ids)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -119,3 +119,7 @@ discourse_translator:
   experimental_inline_translation:
     default: false
     client: true
+  discourse_translator_verbose_logs:
+    default: false
+    client: false
+    hidden: true

--- a/lib/discourse_translator/verbose_logger.rb
+++ b/lib/discourse_translator/verbose_logger.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DiscourseTranslator
+  class VerboseLogger
+    def self.log(message)
+      if SiteSetting.discourse_translator_verbose_logs
+        Rails.logger.info("DiscourseTranslator: #{message}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding a new `DiscourseTranslator::VerboseLogger` to track backfill, but can be used in general.

The associated site setting to turn on is `SiteSetting.discourse_translator_verbose_logs`, then one may visit /logs to check on the backfill job.