### PR TITLE
FIX: Allow user to be deleted

### DIFF
--- a/lib/discourse_translator/guardian_extension.rb
+++ b/lib/discourse_translator/guardian_extension.rb
@@ -22,7 +22,7 @@ module DiscourseTranslator::GuardianExtension
   end
 
   def can_translate?(post)
-    return false if post.user.bot?
+    return false if post.user&.bot?
     return false if !user_group_allow_translate?
     return false if post.locale_matches?(I18n.locale)
 

--- a/spec/lib/guardian_extension_spec.rb
+++ b/spec/lib/guardian_extension_spec.rb
@@ -244,5 +244,11 @@ describe DiscourseTranslator::GuardianExtension do
         end
       end
     end
+
+    it "does not error out when post user is deleted" do
+      post.update(user: nil)
+
+      expect { guardian.can_translate?(post) }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
There is a bug now where the post's user may not always be available, causing `can_translate?` to throw an error.

```
Message (2 copies reported)
NoMethodError (undefined method `bot?' for nil)
app/serializers/post_stream_serializer_mixin.rb:69:in `block in posts'
```

This PR fixes this issue.