### PR TITLE
DEV: Promote severity for logs

### DIFF
--- a/lib/discourse_translator/verbose_logger.rb
+++ b/lib/discourse_translator/verbose_logger.rb
@@ -4,7 +4,7 @@ module DiscourseTranslator
   class VerboseLogger
     def self.log(message)
       if SiteSetting.discourse_translator_verbose_logs
-        Rails.logger.info("DiscourseTranslator: #{message}")
+        Rails.logger.warn("DiscourseTranslator: #{message}")
       end
     end
   end


### PR DESCRIPTION
We would need to enable log shipping if we use `info`, so just use `warn` for now so we don't have to do that extra step.