### PR TITLE
UX: Squarify the Show Original Content button in mobile

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -8,9 +8,6 @@
 }
 
 .topic-navigation.with-topic-progress .discourse-translator_toggle-original {
-}
-
-.topic-navigation.with-topic-progress .discourse-translator_toggle-original {
   height: 100%;
   aspect-ratio: 1/1;
   button {


### PR DESCRIPTION
The button currently looks like this:

<img width="200" alt="Screenshot 2025-03-04 at 2 16 52 PM" src="https://github.com/user-attachments/assets/0ae70d04-93ca-43c6-b644-b5975a9b4bf9" />


With the PR, it will look like this (square, filled):

<img width="347" alt="Screenshot 2025-03-04 at 2 12 48 PM" src="https://github.com/user-attachments/assets/5866bcd8-d7f7-4be6-8050-a72d5b1fd519" />

Desktop unaffected:
<img width="91" alt="Screenshot 2025-03-04 at 2 13 01 PM" src="https://github.com/user-attachments/assets/dab9a98e-2c4b-416f-8121-b47caa1c9698" />


Related: https://github.com/discourse/discourse/pull/30949