### PR TITLE
FEATURE: Add hidden settings to limit automatic translation scope

### DIFF
--- a/app/jobs/scheduled/automatic_translation_backfill.rb
+++ b/app/jobs/scheduled/automatic_translation_backfill.rb
@@ -17,9 +17,11 @@ module Jobs
       DB.query_single(<<~SQL, target_locale: target_locale, limit: limit)
         SELECT m.id
         FROM #{model.table_name} m
+        #{limit_to_public_clause(model)}
         WHERE m.deleted_at IS NULL
           AND m.#{content_column} != ''
           AND m.user_id > 0
+          #{max_age_clause}
           AND (
             NOT EXISTS (
               SELECT 1
@@ -107,6 +109,34 @@ module Jobs
         translate_records(Topic, topic_ids, target_locale)
         translate_records(Post, post_ids, target_locale)
       end
+    end
+
+    def max_age_clause
+      return "" if SiteSetting.automatic_translation_backfill_max_age_days <= 0
+
+      "AND m.created_at > NOW() - INTERVAL '#{SiteSetting.automatic_translation_backfill_max_age_days} days'"
+    end
+
+    def limit_to_public_clause(model)
+      return "" if !SiteSetting.automatic_translation_backfill_limit_to_public_content
+
+      public_categories = Category.where(read_restricted: false).pluck(:id).join(", ")
+      if model == Post
+        limit_to_public_clause = <<~SQL
+          INNER JOIN topics t
+          ON m.topic_id = t.id
+          AND t.archetype = 'regular'
+          AND t.category_id IN (#{public_categories})
+        SQL
+      elsif model == Topic
+        limit_to_public_clause = <<~SQL
+          INNER JOIN categories c
+          ON m.category_id = c.id
+          AND c.id IN (#{public_categories})
+        SQL
+      end
+
+      limit_to_public_clause
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,14 @@ discourse_translator:
     default: 0
     client: false
     hidden: true
+  automatic_translation_backfill_limit_to_public_content:
+    default: false
+    client: false
+    hidden: true
+  automatic_translation_backfill_max_age_days:
+    default: 0
+    client: false
+    hidden: true
   translator_azure_subscription_key:
     default: ''
   translator_azure_region:


### PR DESCRIPTION
- **DEV: Remove manual lock in favor of cluster_concurrency**
- **FEATURE: Add hidden settings to limit automatic translation scope**
