### PR TITLE
UX: fix scaling of translator button in topic-progress bar

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -8,8 +8,8 @@
 }
 
 .topic-navigation.with-topic-progress .discourse-translator_toggle-original {
-  height: 100%;
-  aspect-ratio: 1/1;
+  margin-right: 0.5em;
+  align-self: stretch;
 
   button {
     height: 100%;


### PR DESCRIPTION
Should resolve this issue with the enormous button in some cases 

![image](https://github.com/user-attachments/assets/1d901016-5d7a-4c3e-b5f9-5d751edc33de)


After:

![image](https://github.com/user-attachments/assets/a3b556f3-d983-40e7-9a6c-2e3a51dbfa22)
