### PR TITLE
DEV: Prevent multiple instances of same locale cookie due to path

### DIFF
--- a/assets/javascripts/discourse/components/language-switcher.gjs
+++ b/assets/javascripts/discourse/components/language-switcher.gjs
@@ -28,7 +28,7 @@ export default class LanguageSwitcher extends Component {
 
   @action
   async changeLocale(locale) {
-    cookie("locale", locale, { path: "/"});
+    cookie("locale", locale, { path: "/" });
     this.dMenu.close();
     // we need a hard refresh here for the locale to take effect
     window.location.reload();

--- a/spec/system/anon_language_switcher_spec.rb
+++ b/spec/system/anon_language_switcher_spec.rb
@@ -4,28 +4,29 @@ RSpec.describe "Anonymous user language switcher", type: :system do
   SWITCHER_SELECTOR = "button[data-identifier='discourse-translator_language-switcher']"
 
   let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:switcher) { PageObjects::Components::DMenu.new(SWITCHER_SELECTOR) }
 
   fab!(:japanese_user) { Fabricate(:user, locale: "ja") }
   fab!(:topic) do
     topic = Fabricate(:topic, title: "Life strategies from The Art of War")
-    topic.set_detected_locale("en")
-    topic.set_translation("ja", "孫子兵法からの人生戦略")
-    topic.set_translation("es", "Estrategias de vida de El arte de la guerra")
+    Fabricate(:post, topic:)
     topic
   end
 
-  it "only shows the language switcher based on what is in target languages" do
+  before do
     SiteSetting.translator_enabled = true
     SiteSetting.allow_user_locale = true
     SiteSetting.set_locale_from_cookie = true
     SiteSetting.automatic_translation_backfill_rate = 1
+  end
+
+  it "only shows the language switcher based on what is in target languages" do
     SiteSetting.automatic_translation_target_languages = "es|ja"
     SiteSetting.experimental_anon_language_switcher = true
     visit("/")
 
     expect(page).to have_css(SWITCHER_SELECTOR)
 
-    switcher = PageObjects::Components::DMenu.new(SWITCHER_SELECTOR)
     switcher.expand
     expect(switcher).to have_content("日本語")
     expect(switcher).to have_content("Español")
@@ -39,19 +40,19 @@ RSpec.describe "Anonymous user language switcher", type: :system do
 
   describe "with Spanish and Japanese" do
     before do
-      SiteSetting.translator_enabled = true
-      SiteSetting.allow_user_locale = true
-      SiteSetting.set_locale_from_cookie = true
-      SiteSetting.automatic_translation_backfill_rate = 1
       SiteSetting.automatic_translation_target_languages = "es|ja"
       SiteSetting.experimental_anon_language_switcher = true
+      SiteSetting.experimental_inline_translation = true
+
+      topic.set_detected_locale("en")
+      topic.set_translation("ja", "孫子兵法からの人生戦略")
+      topic.set_translation("es", "Estrategias de vida de El arte de la guerra")
     end
 
     it "shows the correct language based on the selected language and login status" do
       visit("/")
       expect(find(".nav-item_latest")).to have_content("Latest")
 
-      switcher = PageObjects::Components::DMenu.new(SWITCHER_SELECTOR)
       switcher.expand
       switcher.click_button("Español")
       expect(find(".nav-item_latest")).to have_content("Recientes")
@@ -64,7 +65,6 @@ RSpec.describe "Anonymous user language switcher", type: :system do
     it "shows the most recently selected language" do
       visit("/")
 
-      switcher = PageObjects::Components::DMenu.new(SWITCHER_SELECTOR)
       switcher.expand
       switcher.click_button("Español")
       expect(find(".nav-item_latest")).to have_content("Recientes")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/86dc43e9-4e0d-4be4-9cf5-fa449d5189ba)

When using the language switcher, the cookie gets added but the path is not specified, so we may have multiple of the same cookie with varying paths.

This PR fixes the path to root so there won't be dups.