### PR TITLE
FEATURE: Show an indicator for posts not originally written in the user's language

### DIFF
--- a/assets/javascripts/discourse/components/translated-post-indicator.gjs
+++ b/assets/javascripts/discourse/components/translated-post-indicator.gjs
@@ -1,0 +1,19 @@
+import Component from "@glimmer/component";
+import { i18n } from "discourse-i18n";
+import DTooltip from "float-kit/components/d-tooltip";
+
+export default class TranslatedPostIndicator extends Component {
+  get tooltip() {
+    return i18n("translator.originally_written_in", {
+      language: this.args.data.detectedLanguage,
+    });
+  }
+
+  <template>
+    <DTooltip
+      @identifier="discourse-translator_translated-post-indicator"
+      @icon="language"
+      @content={{this.tooltip}}
+    />
+  </template>
+}

--- a/assets/javascripts/discourse/initializers/extend-for-translate-button.js
+++ b/assets/javascripts/discourse/initializers/extend-for-translate-button.js
@@ -1,8 +1,10 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+import RenderGlimmer from "discourse/widgets/render-glimmer";
 import LanguageSwitcher from "../components/language-switcher";
 import ToggleTranslationButton from "../components/post-menu/toggle-translation-button";
 import ShowOriginalContent from "../components/show-original-content";
 import TranslatedPost from "../components/translated-post";
+import TranslatedPostIndicator from "../components/translated-post-indicator";
 
 function initializeTranslation(api) {
   const siteSettings = api.container.lookup("service:site-settings");
@@ -46,6 +48,18 @@ function initializeTranslation(api) {
         });
       }
     );
+
+    api.includePostAttributes("is_translated", "detected_language");
+    api.decorateWidget("post-date:before", (dec) => {
+      if (dec.attrs.is_translated && dec.attrs.detected_language) {
+        return new RenderGlimmer(
+          dec.widget,
+          "div.post-info.post-translated-indicator",
+          TranslatedPostIndicator,
+          { detectedLanguage: dec.attrs.detected_language }
+        );
+      }
+    });
   }
 
   customizePostMenu(api);

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -22,3 +22,11 @@
     color: var(--tertiary);
   }
 }
+
+.post-info .post-info.post-translated-indicator {
+  display: inline;
+
+  svg {
+    color: var(--primary-med-or-secondary-med);
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -12,3 +12,4 @@ en:
       content_translated: "Page is machine-translated. Click to view original"
       translated_from: "Translated from %{language} by %{translator}"
       translating: "Translating"
+      originally_written_in: "This post was originally written in %{language}"

--- a/lib/discourse_translator/inline_translation.rb
+++ b/lib/discourse_translator/inline_translation.rb
@@ -63,7 +63,14 @@ module DiscourseTranslator
       plugin.add_to_serializer(:basic_post, :is_translated) do
         SiteSetting.experimental_inline_translation &&
           !object.locale_matches?(InlineTranslation.effective_locale) &&
+          !scope&.request&.cookies&.key?(SHOW_ORIGINAL_COOKIE) &&
           object.translation_for(InlineTranslation.effective_locale).present?
+      end
+
+      plugin.add_to_serializer(:basic_post, :detected_language) do
+        if SiteSetting.experimental_inline_translation && object.detected_locale.present?
+          LocaleToLanguage.get_language(object.detected_locale)
+        end
       end
 
       plugin.add_to_serializer(:topic_view, :is_translated) do

--- a/lib/discourse_translator/locale_to_language.rb
+++ b/lib/discourse_translator/locale_to_language.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DiscourseTranslator
+  class LocaleToLanguage
+    def self.get_language(locale)
+      LocaleSiteSetting.values.find { |v| v[:value] == locale.to_s.sub("-", "_") }&.[](:name)
+    end
+  end
+end

--- a/spec/lib/locale_to_language_spec.rb
+++ b/spec/lib/locale_to_language_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe DiscourseTranslator::LocaleToLanguage do
+  describe ".get_language" do
+    it "returns the language name for a valid locale" do
+      expect(DiscourseTranslator::LocaleToLanguage.get_language("en")).to eq("English (US)")
+      expect(DiscourseTranslator::LocaleToLanguage.get_language("es")).to eq("Español")
+    end
+
+    it "returns nil for a locale that doesn't exist" do
+      expect(DiscourseTranslator::LocaleToLanguage.get_language("xx")).to be_nil
+    end
+
+    it "handles symbol locales" do
+      expect(DiscourseTranslator::LocaleToLanguage.get_language(:en_GB)).to eq("English (UK)")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a little indicator in each post that shares the original post language. It only shows up when `experimental_inline_translation` is enabled, and if the post's language is not matching the user's locale.


Reviewer note: We're currently using the LocaleSiteSetting values to determine the name of the language, so we will get values like "Español" instead of "Spanish". In the future we will consider localized language names (internal /151409)

<img width="944" alt="Screenshot 2025-04-14 at 8 54 42 PM" src="https://github.com/user-attachments/assets/c6c7b96c-2dd1-49a0-a21c-4338a1fb367c" />
