### PR TITLE
FIX: Show toggle button even when original content is displayed

### DIFF
--- a/assets/javascripts/discourse/components/show-original-content.gjs
+++ b/assets/javascripts/discourse/components/show-original-content.gjs
@@ -11,10 +11,7 @@ const SHOW_ORIGINAL_COOKIE_EXPIRY = 30;
 
 export default class ShowOriginalContent extends Component {
   static shouldRender(args) {
-    return (
-      args.topic.is_translated ||
-      args.topic.postStream.posts.some(({ is_translated }) => is_translated)
-    );
+    return args.topic.show_translation_toggle;
   }
 
   @service router;


### PR DESCRIPTION
A bug exists now where the toggle to display translated content is gone. It should always be there if there is translatable content. (e.g. meta /278426)

<img width="548" alt="image" src="https://github.com/user-attachments/assets/7af5b938-56f4-436b-98d6-4d13a21a5415" />

This PR returns a proper attribute indicating whether the toggle button should be shown or not depending on whether the topic has translations for the user. This is independent of whether the user is seeing translated content or not.