### PR TITLE
DEV: Functional class to get the active selected translator

### DIFF
--- a/app/controllers/discourse_translator/translator_controller.rb
+++ b/app/controllers/discourse_translator/translator_controller.rb
@@ -40,9 +40,11 @@ module ::DiscourseTranslator
 
       begin
         title_json = {}
-        detected_lang, translation = DiscourseTranslator::Provider.get.translate(post)
+        detected_lang, translation =
+          DiscourseTranslator::Provider::TranslatorProvider.get.translate(post)
         if post.is_first_post?
-          _, title_translation = DiscourseTranslator::Provider.get.translate(post.topic)
+          _, title_translation =
+            DiscourseTranslator::Provider::TranslatorProvider.get.translate(post.topic)
           title_json = { title_translation: title_translation }
         end
         render json: { translation: translation, detected_lang: detected_lang }.merge(title_json),

--- a/app/jobs/regular/detect_translatable_language.rb
+++ b/app/jobs/regular/detect_translatable_language.rb
@@ -11,7 +11,7 @@ module ::Jobs
       translatable = args[:type].constantize.find_by(id: args[:translatable_id])
       return if translatable.blank?
       begin
-        translator = DiscourseTranslator::Provider.get
+        translator = DiscourseTranslator::Provider::TranslatorProvider.get
         translator.detect(translatable)
       rescue ::DiscourseTranslator::Provider::ProblemCheckedTranslationError
         # problem-checked translation errors gracefully

--- a/app/jobs/regular/translate_translatable.rb
+++ b/app/jobs/regular/translate_translatable.rb
@@ -11,7 +11,10 @@ module Jobs
 
       target_locales = SiteSetting.automatic_translation_target_languages.split("|")
       target_locales.each do |target_locale|
-        DiscourseTranslator::Provider.get.translate(translatable, target_locale.to_sym)
+        DiscourseTranslator::Provider::TranslatorProvider.get.translate(
+          translatable,
+          target_locale.to_sym,
+        )
       end
 
       topic_id, post_id =

--- a/app/jobs/scheduled/automatic_translation_backfill.rb
+++ b/app/jobs/scheduled/automatic_translation_backfill.rb
@@ -67,7 +67,7 @@ module Jobs
     end
 
     def translator
-      @translator_klass ||= DiscourseTranslator::Provider.get
+      @translator_klass ||= DiscourseTranslator::Provider::TranslatorProvider.get
     end
 
     def translate_records(type, record_ids, target_locale)

--- a/app/services/discourse_translator/provider/translator_provider.rb
+++ b/app/services/discourse_translator/provider/translator_provider.rb
@@ -2,8 +2,10 @@
 
 module DiscourseTranslator
   module Provider
-    def self.get
-      DiscourseTranslator::Provider.get
+    class TranslatorProvider
+      def self.get
+        "DiscourseTranslator::Provider::#{SiteSetting.translator_provider}".constantize
+      end
     end
   end
 end


### PR DESCRIPTION
Moves all usages of `"DiscourseTranslator::Provider::#{SiteSetting.translator_provider}".constantize` to `DiscourseTranslator::Provider::TranslatorProvider.get`.

Prepping for a future PR to translate categories in a job.

Note: I wanted `DiscourseTranslator::Provider.get` but zeitwerk is being annoying. It is a mouthful now unfortunately.