### PR TITLE
FIX: Update localisation instead of category

### DIFF
--- a/app/services/discourse_translator/category_translator.rb
+++ b/app/services/discourse_translator/category_translator.rb
@@ -16,7 +16,16 @@ module DiscourseTranslator
       translated_name = translator.translate_text!(category.name, target_locale_sym)
       translated_description = translator.translate_text!(category.description, target_locale_sym)
 
-      category.update!(name: translated_name, description: translated_description)
+      localization =
+        CategoryLocalization.find_or_initialize_by(
+          category_id: category.id,
+          locale: target_locale_sym.to_s,
+        )
+
+      localization.name = translated_name
+      localization.description = translated_description
+      localization.save!
+      localization
     end
   end
 end

--- a/spec/services/category_translator_spec.rb
+++ b/spec/services/category_translator_spec.rb
@@ -21,23 +21,48 @@ describe DiscourseTranslator::CategoryTranslator do
         .with(category.description, target_locale)
         .returns("C'est une catégorie de test")
 
+      res = DiscourseTranslator::CategoryTranslator.translate(category, target_locale)
+
+      expect(res.name).to eq("Catégorie de Test")
+      expect(res.description).to eq("C'est une catégorie de test")
+    end
+
+    it "translates the category name and description" do
+      localized =
+        Fabricate(
+          :category_localization,
+          category: category,
+          locale: target_locale,
+          name: "X",
+          description: "Y",
+        )
+      translator
+        .expects(:translate_text!)
+        .with(category.name, target_locale)
+        .returns("Catégorie de Test")
+      translator
+        .expects(:translate_text!)
+        .with(category.description, target_locale)
+        .returns("C'est une catégorie de test")
+
       DiscourseTranslator::CategoryTranslator.translate(category, target_locale)
 
-      expect(category.name).to eq("Catégorie de Test")
-      expect(category.description).to eq("C'est une catégorie de test")
+      localized.reload
+      expect(localized.name).to eq("Catégorie de Test")
+      expect(localized.description).to eq("C'est une catégorie de test")
     end
 
     it "handles locale format standardization" do
-      translator.expects(:translate_text!).with(category.name, :fr_CA).returns("Catégorie de Test")
+      translator.expects(:translate_text!).with(category.name, :fr).returns("Catégorie de Test")
       translator
         .expects(:translate_text!)
-        .with(category.description, :fr_CA)
+        .with(category.description, :fr)
         .returns("C'est une catégorie de test")
 
-      DiscourseTranslator::CategoryTranslator.translate(category, "fr-CA")
+      res = DiscourseTranslator::CategoryTranslator.translate(category, "fr")
 
-      expect(category.name).to eq("Catégorie de Test")
-      expect(category.description).to eq("C'est une catégorie de test")
+      expect(res.name).to eq("Catégorie de Test")
+      expect(res.description).to eq("C'est une catégorie de test")
     end
 
     it "returns nil if category is blank" do
@@ -56,10 +81,11 @@ describe DiscourseTranslator::CategoryTranslator do
         .with(category.description, :es)
         .returns("Esta es una categoría de prueba")
 
-      DiscourseTranslator::CategoryTranslator.translate(category)
+      res = DiscourseTranslator::CategoryTranslator.translate(category)
 
-      expect(category.name).to eq("Categoría de Prueba")
-      expect(category.description).to eq("Esta es una categoría de prueba")
+      expect(res.name).to eq("Categoría de Prueba")
+      expect(res.description).to eq("Esta es una categoría de prueba")
+      expect(res.locale).to eq("es")
     end
   end
 end


### PR DESCRIPTION
Followup fix to https://github.com/discourse/discourse-translator/pull/282. We were updating categories instead of the localizations.