### PR TITLE
DEV: prevents double navigation

### DIFF
--- a/spec/system/anon_language_switcher_spec.rb
+++ b/spec/system/anon_language_switcher_spec.rb
@@ -67,17 +67,20 @@ RSpec.describe "Anonymous user language switcher", type: :system do
 
       switcher.expand
       switcher.click_button("Español")
+
       expect(find(".nav-item_latest")).to have_content("Recientes")
 
       topic_page.visit_topic(topic)
-      topic_page.has_topic_title?("Estrategias de vida de El arte de la guerra")
+
+      expect(topic_page).to have_topic_title("Estrategias de vida de El arte de la guerra")
 
       switcher.expand
       switcher.click_button("日本語")
-      topic_page.visit_topic(topic)
-      topic_page.has_topic_title?("孫子兵法からの人生戦略")
+
+      expect(topic_page).to have_topic_title("孫子兵法からの人生戦略")
 
       visit("/")
+
       expect(find(".nav-item_latest")).to have_content("最新")
     end
   end


### PR DESCRIPTION
Clicking on the switcher is already causing a navigation to the topic to refresh content. In this spec we were doing a `visit_topic` right after which could be working in selenium, but will often fail on playwright with the following error:

```ruby
 Playwright::Error:
   net::ERR_ABORTED at http://localhost:31339/t/life-strategies-from-the-art-of-war/96
   Call log:
     - navigating to "http://localhost:31339/t/life-strategies-from-the-art-of-war/96", waiting until "load"
```