### PR TITLE
FIX: Ensure untranslated post ids exclude those already translated to target locale

### DIFF
--- a/spec/jobs/automatic_translation_backfill_spec.rb
+++ b/spec/jobs/automatic_translation_backfill_spec.rb
@@ -251,5 +251,13 @@ This is the scenario we are testing for:
 
       expect(result).not_to include(post_1.id)
     end
+
+    it "does not return posts that already have the target locale translation, even if detected_locale is not the target" do
+      post_7.set_detected_locale("en")
+      post_7.set_translation("de", "hallo")
+
+      result = described_class.new.fetch_untranslated_model_ids(Post, "raw", 50, "de")
+      expect(result).not_to include(post_7.id)
+    end
   end
 end


### PR DESCRIPTION
This PR corrects the logic in fetch_untranslated_model_ids to prevent posts/topics that already have a translation in the target locale from being returned for backfill. Previously, the SQL query only excluded posts where the detected locale and translation were both present for the target locale, resulting in posts with existing translations being included when their detected_locale was different.

Related: https://github.com/discourse/discourse-translator/pull/255