### PR TITLE
DEV: Rename a setting so that posts and topics can use it too

### DIFF
--- a/app/jobs/regular/translate_categories.rb
+++ b/app/jobs/regular/translate_categories.rb
@@ -7,7 +7,7 @@ module Jobs
 
     def execute(args)
       return unless SiteSetting.translator_enabled
-      return unless SiteSetting.experimental_category_translation
+      return unless SiteSetting.experimental_content_translation
 
       locales = SiteSetting.automatic_translation_target_languages.split("|")
       return if locales.blank?

--- a/app/jobs/scheduled/automatic_category_translation.rb
+++ b/app/jobs/scheduled/automatic_category_translation.rb
@@ -7,7 +7,7 @@ module Jobs
 
     def execute(args)
       return unless SiteSetting.translator_enabled
-      return unless SiteSetting.experimental_category_translation
+      return unless SiteSetting.experimental_content_translation
 
       locales = SiteSetting.automatic_translation_target_languages.split("|")
       return if locales.blank?

--- a/app/services/discourse_translator/provider/base_provider.rb
+++ b/app/services/discourse_translator/provider/base_provider.rb
@@ -65,7 +65,7 @@ module DiscourseTranslator
         raise "Not Implemented"
       end
 
-      def self.translate_text(text, target_locale_sym = I18n.locale)
+      def self.translate_text!(text, target_locale_sym = I18n.locale)
         raise "Not Implemented"
       end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -129,7 +129,7 @@ discourse_translator:
   experimental_inline_translation:
     default: false
     client: true
-  experimental_category_translation:
+  experimental_content_translation:
     default: false
     hidden: true
   discourse_translator_verbose_logs:

--- a/db/migrate/20250429102109_rename_site_setting_content_translation.rb
+++ b/db/migrate/20250429102109_rename_site_setting_content_translation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RenameSiteSettingContentTranslation < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'experimental_content_translation'
+      WHERE name = 'experimental_category_translation';
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'experimental_category_translation'
+      WHERE name = 'experimental_content_translation';
+    SQL
+  end
+end

--- a/spec/jobs/translate_categories_spec.rb
+++ b/spec/jobs/translate_categories_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
 describe Jobs::TranslateCategories do
   subject(:job) { described_class.new }
 
@@ -15,7 +13,7 @@ describe Jobs::TranslateCategories do
 
   before do
     SiteSetting.translator_enabled = true
-    SiteSetting.experimental_category_translation = true
+    SiteSetting.experimental_content_translation = true
     SiteSetting.automatic_translation_backfill_rate = 100
     SiteSetting.automatic_translation_target_languages = "pt|zh_CN"
 
@@ -31,8 +29,8 @@ describe Jobs::TranslateCategories do
     job.execute({})
   end
 
-  it "does nothing when experimental_category_translation is disabled" do
-    SiteSetting.experimental_category_translation = false
+  it "does nothing when experimental_content_translation is disabled" do
+    SiteSetting.experimental_content_translation = false
 
     translator.expects(:translate_text!).never
 


### PR DESCRIPTION
Earlier on in https://github.com/discourse/discourse-translator/pull/282 we introduced a setting for categories only. That is quite short-sighted so the setting is now for all user generated content `experimental_content_translation`.

This will be used in the next PR that translates posts and topics.