### PR TITLE
FIX: Don't double cook

### DIFF
--- a/app/models/concerns/discourse_translator/translatable.rb
+++ b/app/models/concerns/discourse_translator/translatable.rb
@@ -15,6 +15,7 @@ module DiscourseTranslator
       # locales should be "en-US" instead of "en_US" per https://www.rfc-editor.org/rfc/rfc5646#section-2.1
       locale = locale.to_s.gsub("_", "-")
       (content_locale || build_content_locale).update!(detected_locale: locale)
+      locale
     end
 
     # This method is used to create a translation for a translatable (Post or Topic) and a specific locale.

--- a/app/services/discourse_translator/provider/google.rb
+++ b/app/services/discourse_translator/provider/google.rb
@@ -96,14 +96,15 @@ module DiscourseTranslator
         end
       end
 
-      def self.translate_translatable!(translatable, target_locale_sym = I18n.locale)
-        res =
-          result(
-            TRANSLATE_URI,
-            q: text_for_translation(translatable),
-            target: SUPPORTED_LANG_MAPPING[target_locale_sym],
-          )
-        res["translations"][0]["translatedText"]
+      def self.translate_post!(post, target_locale_sym = I18n.locale, opts = {})
+        raw = opts.key?(:raw) ? opts[:raw] : !opts[:cooked]
+        text = text_for_translation(post, raw:)
+        translate_text!(text, target_locale_sym)
+      end
+
+      def self.translate_topic!(topic, target_locale_sym = I18n.locale)
+        text = text_for_translation(topic)
+        translate_text!(text, target_locale_sym)
       end
 
       def self.translate_text!(text, target_locale_sym = I18n.locale)

--- a/app/services/discourse_translator/provider/libre_translate.rb
+++ b/app/services/discourse_translator/provider/libre_translate.rb
@@ -91,18 +91,19 @@ module DiscourseTranslator
         res.any? { |obj| obj["code"] == source } && res.any? { |obj| obj["code"] == lang }
       end
 
-      def self.translate_translatable!(translatable, target_locale_sym = I18n.locale)
-        detected_lang = detect(translatable)
+      def self.translate_post!(post, target_locale_sym = I18n.locale, opts = {})
+        raw = opts.key?(:raw) ? opts[:raw] : !opts[:cooked]
+        text = text_for_translation(post, raw:)
 
-        res =
-          result(
-            translate_uri,
-            q: text_for_translation(translatable),
-            source: detected_lang,
-            target: SUPPORTED_LANG_MAPPING[target_locale_sym],
-            format: "html",
-          )
-        res["translatedText"]
+        detected_lang = detect(post)
+
+        send_for_translation(text, detected_lang, target_locale_sym)
+      end
+
+      def self.translate_topic!(topic, target_locale_sym = I18n.locale)
+        detected_lang = detect(topic)
+        text = text_for_translation(topic)
+        send_for_translation(text, detected_lang, target_locale_sym)
       end
 
       def self.translate_text!(text, target_locale_sym = I18n.locale)
@@ -153,6 +154,20 @@ module DiscourseTranslator
         else
           body
         end
+      end
+
+      private
+
+      def self.send_for_translation(text, source_locale, target_locale)
+        res =
+          result(
+            translate_uri,
+            q: text,
+            source: source_locale,
+            target: SUPPORTED_LANG_MAPPING[target_locale],
+            format: "html",
+          )
+        res["translatedText"]
       end
     end
   end

--- a/spec/services/discourse_ai_spec.rb
+++ b/spec/services/discourse_ai_spec.rb
@@ -34,7 +34,7 @@ describe DiscourseTranslator::Provider::DiscourseAi do
     end
   end
 
-  describe ".translate_translatable!" do
+  describe ".translate_post!" do
     before do
       post.set_detected_locale("de")
       topic.set_detected_locale("de")
@@ -42,15 +42,7 @@ describe DiscourseTranslator::Provider::DiscourseAi do
 
     it "translates the post and returns [locale, translated_text]" do
       DiscourseAi::Completions::Llm.with_prepared_responses(["some translated text"]) do
-        translated_text = DiscourseTranslator::Provider::DiscourseAi.translate_translatable!(post)
-        expect(translated_text).to eq "<p>some translated text</p>"
-      end
-    end
-
-    it "translates the topic" do
-      allow(::DiscourseAi::TopicTranslator).to receive(:new).and_call_original
-      DiscourseAi::Completions::Llm.with_prepared_responses(["some translated text"]) do
-        translated_text = DiscourseTranslator::Provider::DiscourseAi.translate_translatable!(topic)
+        translated_text = DiscourseTranslator::Provider::DiscourseAi.translate_post!(post)
         expect(translated_text).to eq "some translated text"
       end
     end
@@ -58,9 +50,17 @@ describe DiscourseTranslator::Provider::DiscourseAi do
     it "sends the content for splitting and the split content for translation" do
       post.update(raw: "#{"a" * 3000} #{"b" * 3000}")
       DiscourseAi::Completions::Llm.with_prepared_responses(%w[lol wut]) do
-        expect(
-          DiscourseTranslator::Provider::DiscourseAi.translate_translatable!(post),
-        ).to eq "<p>lolwut</p>"
+        expect(DiscourseTranslator::Provider::DiscourseAi.translate_post!(post)).to eq "lolwut"
+      end
+    end
+  end
+
+  describe ".translate_topic!" do
+    it "translates the topic" do
+      allow(::DiscourseAi::TopicTranslator).to receive(:new).and_call_original
+      DiscourseAi::Completions::Llm.with_prepared_responses(["some translated text"]) do
+        translated_text = DiscourseTranslator::Provider::DiscourseAi.translate_topic!(topic)
+        expect(translated_text).to eq "some translated text"
       end
     end
   end

--- a/spec/services/microsoft_spec.rb
+++ b/spec/services/microsoft_spec.rb
@@ -1,16 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe DiscourseTranslator::Provider::Microsoft do
-  before { SiteSetting.translator_enabled = true }
+  before do
+    SiteSetting.translator_enabled = true
+    SiteSetting.translator_azure_subscription_key = "e1bba646088021aaf1ef972a48"
+  end
   after { Discourse.redis.del(described_class.cache_key) }
 
-  def translate_endpoint(from: "en", to: I18n.locale)
+  def translate_endpoint(to: I18n.locale)
     uri = URI(described_class.translate_endpoint)
     default_query = described_class.default_query.merge("textType" => "html")
-    default_query = default_query.merge("from" => from) if from
     default_query = default_query.merge("to" => to) if to
     uri.query = URI.encode_www_form(default_query)
     uri.to_s
+  end
+
+  def stub_translate_request(source_text, target_locale, translated_text)
+    stub_request(:post, translate_endpoint(to: target_locale)).with(
+      { body: [{ "Text" => source_text }].to_json },
+    ).to_return(status: 200, body: [{ "translations" => [{ "text" => translated_text }] }].to_json)
   end
 
   describe ".detect" do
@@ -110,6 +118,7 @@ RSpec.describe DiscourseTranslator::Provider::Microsoft do
 
     context "without azure key" do
       it "raise a MicrosoftNoAzureKeyError" do
+        SiteSetting.translator_azure_subscription_key = ""
         expect { described_class.detect(post) }.to raise_error(
           DiscourseTranslator::Provider::ProblemCheckedTranslationError,
           I18n.t("translator.microsoft.missing_key"),
@@ -118,104 +127,65 @@ RSpec.describe DiscourseTranslator::Provider::Microsoft do
     end
   end
 
-  describe ".translate" do
-    let(:post) { Fabricate(:post) }
+  describe ".translate_post!" do
+    fab!(:post) { Fabricate(:post, raw: "rawraw rawrawraw", cooked: "coocoo coococooo") }
 
     before do
       post.set_detected_locale("en")
-      SiteSetting.translator_azure_subscription_key = "e1bba646088021aaf1ef972a48"
+      I18n.locale = :de
     end
 
-    shared_examples "post translated" do
-      it "translates post" do
-        I18n.locale = "de"
+    it "translates post with raw" do
+      translated_text = "some text"
+      target_locale = "de"
+      stub_translate_request(post.raw, target_locale, translated_text)
 
-        stub_request(:post, translate_endpoint).to_return(
-          status: 200,
-          body: [{ "translations" => [{ "text" => "some de text" }] }].to_json,
-        )
-
-        expect(described_class.translate(post)).to eq(["en", "some de text"])
-      end
+      expect(described_class.translate_post!(post, :de, { raw: true })).to eq(translated_text)
     end
 
-    context "with a custom endpoint" do
-      before { SiteSetting.translator_azure_custom_subdomain = "translator19191" }
+    it "translates post with cooked" do
+      translated_text = "some text"
+      target_locale = "de"
+      stub_translate_request(post.cooked, target_locale, translated_text)
 
-      include_examples "post translated"
+      expect(described_class.translate_post!(post, :de, { cooked: true })).to eq(translated_text)
     end
 
-    context "without a custom endpoint" do
-      include_examples "post translated"
+    it "translates post with raw when unspecified" do
+      translated_text = "some text"
+      target_locale = "de"
+      stub_translate_request(post.raw, target_locale, translated_text)
 
-      it "returns stored translation if post has already been translated" do
-        I18n.locale = "en"
+      expect(described_class.translate_post!(post, :de)).to eq(translated_text)
+    end
+  end
 
-        post.set_detected_locale("tr")
-        post.set_translation("en", "some english text")
+  describe ".translate_topic!" do
+    fab!(:topic)
 
-        expect(described_class.translate(post)).to eq(["tr", "some english text"])
-      end
+    before do
+      topic.set_detected_locale("en")
+      I18n.locale = :de
+    end
 
-      it "raises an error if detected language of the post is not supported" do
-        post.set_detected_locale("donkey")
+    it "translates topic's title" do
+      translated_text = "some text"
+      target_locale = "de"
+      stub_translate_request(topic.title, target_locale, translated_text)
 
-        expect { described_class.translate(post) }.to raise_error(
-          DiscourseTranslator::Provider::TranslatorError,
-          I18n.t("translator.failed.post", source_locale: "donkey", target_locale: I18n.locale),
-        )
-      end
-
-      it "raises an error if the post is too long to be translated" do
-        I18n.locale = "ja"
-        SiteSetting.max_characters_per_translation = 100_000
-        post.update_columns(
-          cooked: "*" * (DiscourseTranslator::Provider::Microsoft::LENGTH_LIMIT + 1),
-        )
-
-        expect { described_class.translate(post) }.to raise_error(
-          DiscourseTranslator::Provider::TranslatorError,
-          I18n.t("translator.too_long"),
-        )
-      end
-
-      it "raises an error on failure" do
-        I18n.locale = "ja"
-        stub_request(
-          :post,
-          "https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=en&textType=html&to=ja",
-        ).with(
-          body: "[{\"Text\":\"\\u003cp\\u003eHello world\\u003c/p\\u003e\"}]",
-          headers: {
-            "Ocp-Apim-Subscription-Key" => SiteSetting.translator_azure_subscription_key,
-            "Content-Type" => "application/json",
-          },
-        ).to_return(
-          status: 400,
-          body: {
-            error: "something went wrong",
-            error_description: "you passed in a wrong param",
-          }.to_json,
-        )
-
-        expect { described_class.translate(post) }.to raise_error(
-          DiscourseTranslator::Provider::TranslatorError,
-        )
-      end
+      expect(described_class.translate_topic!(topic, :de)).to eq(translated_text)
     end
   end
 
   describe ".translate_text!" do
     it "translates text" do
-      text = "ABCDEFG"
-      SiteSetting.translator_azure_subscription_key = "123123"
-
       I18n.locale = :es
-      stub_request(:post, translate_endpoint(from: nil, to: "es")).with(
-        { body: [{ "Text" => text }].to_json },
-      ).to_return(status: 200, body: [{ "translations" => [{ "text" => "some text" }] }].to_json)
 
-      expect(described_class.translate_text!(text)).to eq("some text")
+      text = "ABCDEFG"
+      translated_text = "some text"
+      stub_translate_request(text, "es", translated_text)
+
+      expect(described_class.translate_text!(text)).to eq(translated_text)
     end
   end
 end


### PR DESCRIPTION
This PR fixes the bug where we were double-cooking when saving `PostLocalization` when the AI provider is used.

The reason is due to the fact that we used to translate raw, then cook, and save the cooked. But now, we are required to save both the raw and cooked into `PostLocalization`.

This PR also splits `translate_translatable` into `translate_post` and `translate_topic`. Originally they were taking the same route, but it was proving to be a bit annoying because post uses raw and cooked, whereas topic uses title. It makes understanding any issues with a single model (e.g. Posts) easier to understand if it is a single code path. Lastly, PR also fixes an Amazon provider bug as it was never tested.