### PR TITLE
FIX: Suppress errors when translating

### DIFF
--- a/app/jobs/regular/detect_translate_post.rb
+++ b/app/jobs/regular/detect_translate_post.rb
@@ -20,6 +20,8 @@ module Jobs
 
         begin
           DiscourseTranslator::PostTranslator.translate(post, locale)
+        rescue FinalDestination::SSRFDetector::LookupFailedError
+          # do nothing, there are too many sporadic lookup failures
         rescue => e
           Rails.logger.error(
             "Discourse Translator: Failed to translate post #{post.id} to #{locale}: #{e.message}",

--- a/app/jobs/regular/detect_translate_topic.rb
+++ b/app/jobs/regular/detect_translate_topic.rb
@@ -22,6 +22,8 @@ module Jobs
 
         begin
           DiscourseTranslator::TopicTranslator.translate(topic, locale)
+        rescue FinalDestination::SSRFDetector::LookupFailedError
+          # do nothing, there are too many sporadic lookup failures
         rescue => e
           Rails.logger.error(
             "Discourse Translator: Failed to translate topic #{topic.id} to #{locale}: #{e.message}",

--- a/app/jobs/regular/translate_categories.rb
+++ b/app/jobs/regular/translate_categories.rb
@@ -26,6 +26,8 @@ module Jobs
             next if CategoryLocalization.exists?(category_id: category.id, locale: locale)
             begin
               DiscourseTranslator::CategoryTranslator.translate(category, locale)
+            rescue FinalDestination::SSRFDetector::LookupFailedError
+              # do nothing, there are too many sporadic lookup failures
             rescue => e
               Rails.logger.error(
                 "Discourse Translator: Failed to translate category #{category.id} to #{locale}: #{e.message}",

--- a/app/jobs/regular/translate_posts.rb
+++ b/app/jobs/regular/translate_posts.rb
@@ -35,6 +35,8 @@ module Jobs
         posts.each do |post|
           begin
             DiscourseTranslator::PostTranslator.translate(post, locale)
+          rescue FinalDestination::SSRFDetector::LookupFailedError
+            # do nothing, there are too many sporadic lookup failures
           rescue => e
             Rails.logger.error(
               "Discourse Translator: Failed to translate post #{post.id} to #{locale}: #{e.message}",

--- a/app/jobs/regular/translate_topics.rb
+++ b/app/jobs/regular/translate_topics.rb
@@ -34,6 +34,8 @@ module Jobs
         topics.each do |topic|
           begin
             DiscourseTranslator::TopicTranslator.translate(topic, locale)
+          rescue FinalDestination::SSRFDetector::LookupFailedError
+            # do nothing, there are too many sporadic lookup failures
           rescue => e
             Rails.logger.error(
               "Discourse Translator: Failed to translate topic #{topic.id} to #{locale}: #{e.message}",

--- a/app/services/discourse_translator/post_locale_detector.rb
+++ b/app/services/discourse_translator/post_locale_detector.rb
@@ -8,7 +8,7 @@ module DiscourseTranslator
       translator = DiscourseTranslator::Provider::TranslatorProvider.get
       detected_locale = translator.detect!(post)
       locale = LocaleNormalizer.normalize_to_i18n(detected_locale)
-      post.update!(locale:)
+      post.update_column(:locale, locale)
       locale
     end
   end

--- a/spec/services/post_locale_detector_spec.rb
+++ b/spec/services/post_locale_detector_spec.rb
@@ -23,5 +23,14 @@ describe DiscourseTranslator::PostLocaleDetector do
         "zh_CN",
       )
     end
+
+    it "bypasses validations when updating locale" do
+      post.update_column(:raw, "A")
+
+      translator.stubs(:detect!).with(post).returns("zh_CN")
+
+      described_class.detect_locale(post)
+      expect(post.reload.locale).to eq("zh_CN")
+    end
   end
 end


### PR DESCRIPTION
There are two errors here being handled
- Random finaldestination lookup errors when hitting the API. This is not automatically caught at the `translate` method on purpose, but rather at the usages.
- validation errors when updating locale. Sometimes posts are created bypassing validations, when updating the locale, we need to bypass validation as well else the locale can never be updated.