### PR TITLE
DEV: Clean up amazon translations due to parsing error

### DIFF
--- a/db/migrate/20250522045138_cleanup_amazon_translations.rb
+++ b/db/migrate/20250522045138_cleanup_amazon_translations.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CleanupAmazonTranslations < ActiveRecord::Migration[7.2]
+  def up
+    provider =
+      DB.query_single("SELECT value FROM site_settings WHERE name = 'translator_provider'").first
+    if provider == "Amazon"
+      execute <<~SQL
+        DELETE FROM discourse_translator_post_translations
+        WHERE translation LIKE '{:translated_text%'
+      SQL
+
+      execute <<~SQL
+        DELETE FROM discourse_translator_topic_translations
+        WHERE translation LIKE '{:translated_text%'
+      SQL
+    end
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
In https://github.com/discourse/discourse-translator/pull/203 we introduced a bug for the amazon provider, which was fixed in https://github.com/discourse/discourse-translator/pull/297.

This PR is a migration to purge the incorrect translations that have been stored. The translation will look like the following as the full response is saved instead of the specific attribute.

```
{translated_text: ...
```