### PR TITLE
FIX: Microsoft Azure language support

### DIFF
--- a/app/services/discourse_translator/provider/microsoft.rb
+++ b/app/services/discourse_translator/provider/microsoft.rb
@@ -180,9 +180,12 @@ module DiscourseTranslator
         response_body.first["translations"].first["text"]
       end
 
-      def self.translate_supported?(detected_lang, target_lang)
-        SUPPORTED_LANG_MAPPING.keys.include?(detected_lang.to_sym) &&
-          SUPPORTED_LANG_MAPPING.values.include?(detected_lang.to_s)
+      def self.translate_supported?(detected, target)
+        s = SUPPORTED_LANG_MAPPING
+
+        # Azure language support indicates to and from language codes
+        (s.keys.include?(target.to_sym) || s.values.include?(target.to_s)) &&
+          (s.keys.include?(detected.to_sym) || s.values.include?(detected.to_s))
       end
 
       private

--- a/spec/services/microsoft_spec.rb
+++ b/spec/services/microsoft_spec.rb
@@ -188,4 +188,16 @@ RSpec.describe DiscourseTranslator::Provider::Microsoft do
       expect(described_class.translate_text!(text)).to eq(translated_text)
     end
   end
+
+  describe ".translate_supported?" do
+    it "allows translation of topics in supported languages" do
+      expect(described_class.translate_supported?(:en, "zh-Hans")).to eq(true)
+      expect(described_class.translate_supported?("en", :zh_CN)).to eq(true)
+      expect(described_class.translate_supported?("zh-Hans", :en)).to eq(true)
+      expect(described_class.translate_supported?(:zh_CN, "en")).to eq(true)
+
+      expect(described_class.translate_supported?(:tr, "en")).to eq(true)
+      expect(described_class.translate_supported?("tr", "en")).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
A 9-year old bug! https://github.com/discourse/discourse-translator/commit/d4ac527ded922f99848ead8b7e06b8571dd4b841

We were checking if the detected language was in the key and value which would fail if the keys and values are not identical. This improves the check so "zh-Hans" (value returned by Azure) to "en" (`I18n.locale`) is true instead of false.